### PR TITLE
Replace teal with sky and gray with zinc colors

### DIFF
--- a/app/Livewire/Tools/ApiExplorer/BaseApiEndpoint.php
+++ b/app/Livewire/Tools/ApiExplorer/BaseApiEndpoint.php
@@ -130,7 +130,7 @@ abstract class BaseApiEndpoint extends Component
     {
         return <<<'HTML'
         <div class="flex items-center justify-center h-12 mx-auto w-full">
-            <flux:icon.loading class="w-6 h-6 text-gray-400 animate-spin" />
+            <flux:icon.loading class="w-6 h-6 text-zinc-400 animate-spin" />
         </div>
         HTML;
     }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -4,6 +4,7 @@ namespace App\Providers;
 
 use App\Http\ViewComposers\HeaderViewComposer;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Pagination\Paginator;
 use Illuminate\Support\Facades\View;
 use Illuminate\Support\ServiceProvider;
 
@@ -31,5 +32,6 @@ class AppServiceProvider extends ServiceProvider
         Model::preventLazyLoading(); // Prevent lazy loading of models
 
         View::composer('*', HeaderViewComposer::class);
+        Paginator::defaultView('pagination::tailwind');
     }
 }

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -13,20 +13,8 @@
     --font-sans: 'Inter', ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol',
     'Noto Color Emoji';
 
-    --color-zinc-50: var(--color-gray-50);
-    --color-zinc-100: var(--color-gray-100);
-    --color-zinc-200: var(--color-gray-200);
-    --color-zinc-300: var(--color-gray-300);
-    --color-zinc-400: var(--color-gray-400);
-    --color-zinc-500: var(--color-gray-500);
-    --color-zinc-600: var(--color-gray-600);
-    --color-zinc-700: var(--color-gray-700);
-    --color-zinc-800: var(--color-gray-800);
-    --color-zinc-900: var(--color-gray-900);
-    --color-zinc-950: var(--color-gray-950);
-
-    --color-accent: var(--color-teal-600);
-    --color-accent-content: var(--color-teal-600);
+    --color-accent: var(--color-sky-600);
+    --color-accent-content: var(--color-sky-600);
     --color-accent-foreground: var(--color-white);
 
     --color-warning: oklch(76.9% 0.188 70.08);
@@ -57,8 +45,8 @@
     }
 
     .dark {
-        --color-accent: var(--color-teal-600);
-        --color-accent-content: var(--color-teal-400);
+        --color-accent: var(--color-sky-600);
+        --color-accent-content: var(--color-sky-400);
         --color-accent-foreground: var(--color-white);
     }
 }
@@ -87,7 +75,7 @@
     ::before,
     ::backdrop,
     ::file-selector-button {
-        border-color: var(--color-gray-200, currentColor);
+        border-color: var(--color-zinc-200, currentColor);
     }
 
     @font-face {
@@ -147,7 +135,7 @@ select:focus[data-flux-control] {
     transform: translateY(-50%);
     width: 24px;
     height: 24px;
-    border: 1px solid var(--color-gray-200);
+    border: 1px solid var(--color-zinc-200);
     border-radius: 4px;
     z-index: 2;
     background: transparent;
@@ -178,5 +166,5 @@ select:focus[data-flux-control] {
 
 /* For dark mode */
 .dark .clr-field [aria-labelledby="clr-open-label"] {
-    border-color: var(--color-gray-600);
+    border-color: var(--color-zinc-600);
 }

--- a/resources/js/clipboard.js
+++ b/resources/js/clipboard.js
@@ -112,7 +112,7 @@ window.clipboardUtils = {
                 ? 'bg-green-600 text-white'
                 : type === 'error'
                   ? 'bg-red-600 text-white'
-                  : 'bg-gray-800 text-white'
+                  : 'bg-zinc-800 text-white'
         }`;
         tooltip.textContent = message;
 

--- a/resources/views/components/filter-button.blade.php
+++ b/resources/views/components/filter-button.blade.php
@@ -9,8 +9,8 @@
     href="{{ route('notifications', array_merge(request()->query() ?? [], [$query => $filter])) }}"
     {{
         $attributes->class([
-            'bg-teal-100 text-teal-700 dark:bg-teal-900 dark:text-teal-300' => $isActive, // Use isActive prop
-            'text-gray-700 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-700' => ! $isActive, // Use isActive prop
+            'bg-sky-100 text-zinc-700 dark:bg-sky-900 dark:text-zinc-300' => $isActive, // Use isActive prop
+            'text-zinc-700 hover:bg-zinc-100 dark:text-zinc-300 dark:hover:bg-zinc-700' => ! $isActive, // Use isActive prop
             'flex items-center gap-2 rounded-md p-2',
         ])
     }}

--- a/resources/views/components/layouts/app/header.blade.php
+++ b/resources/views/components/layouts/app/header.blade.php
@@ -24,7 +24,7 @@
                     x-data="notificationBadge"
                     icon="bell"
                     :badge="auth()->check() ? auth()->user()->unreadNotifications()->count() : 0"
-                    badge-color="teal"
+                    badge-color="sky"
                     :href="route('notifications')"
                     :current="request()->routeIs('notifications')"
                     x-init=""
@@ -251,7 +251,7 @@
                         if (!badgeSpan && this.currentCount > 0) {
                             badgeSpan = document.createElement('span');
                             badgeSpan.className =
-                                'text-xs font-medium rounded-sm px-1 py-0.5 text-teal-800 dark:text-teal-200 bg-teal-400/20 dark:bg-teal-400/40 ms-2';
+                                'text-xs font-medium rounded-sm px-1 py-0.5 text-sky-800 dark:text-sky-200 bg-sky-400/20 dark:bg-sky-400/40 ms-2';
                             badgeElement.appendChild(badgeSpan);
                         }
 

--- a/resources/views/components/layouts/app/sidebar.blade.php
+++ b/resources/views/components/layouts/app/sidebar.blade.php
@@ -58,7 +58,7 @@
                             <div class="flex items-center gap-2 px-1 py-1.5 text-left text-sm">
                                 <span class="relative flex h-8 w-8 shrink-0 overflow-hidden rounded-lg">
                                     <span
-                                        class="flex h-full w-full items-center justify-center rounded-lg bg-neutral-200 text-black dark:bg-neutral-700 dark:text-white"
+                                        class="flex h-full w-full items-center justify-center rounded-lg bg-zinc-200 text-black dark:bg-zinc-700 dark:text-white"
                                     >
                                         {{ auth()->user()->initials() }}
                                     </span>
@@ -107,7 +107,7 @@
                             <div class="flex items-center gap-2 px-1 py-1.5 text-left text-sm">
                                 <span class="relative flex h-8 w-8 shrink-0 overflow-hidden rounded-lg">
                                     <span
-                                        class="flex h-full w-full items-center justify-center rounded-lg bg-neutral-200 text-black dark:bg-neutral-700 dark:text-white"
+                                        class="flex h-full w-full items-center justify-center rounded-lg bg-zinc-200 text-black dark:bg-zinc-700 dark:text-white"
                                     >
                                         {{ auth()->user()->initials() }}
                                     </span>

--- a/resources/views/components/layouts/auth/card.blade.php
+++ b/resources/views/components/layouts/auth/card.blade.php
@@ -3,7 +3,7 @@
     <head>
         @include('partials.head')
     </head>
-    <body class="min-h-screen bg-neutral-100 antialiased dark:bg-linear-to-b dark:from-neutral-950 dark:to-neutral-900">
+    <body class="min-h-screen bg-zinc-100 antialiased dark:bg-linear-to-b dark:from-zinc-950 dark:to-zinc-900">
         <div class="flex min-h-svh flex-col items-center justify-center gap-6 bg-muted p-6 md:p-10">
             <div class="flex w-full max-w-md flex-col gap-6">
                 <a href="{{ route('home') }}" class="flex flex-col items-center gap-2 font-medium" wire:navigate>

--- a/resources/views/components/layouts/auth/simple.blade.php
+++ b/resources/views/components/layouts/auth/simple.blade.php
@@ -3,12 +3,12 @@
     <head>
         @include('partials.head')
     </head>
-    <body class="min-h-screen bg-white antialiased dark:bg-linear-to-b dark:from-neutral-950 dark:to-neutral-900">
+    <body class="min-h-screen bg-white antialiased dark:bg-linear-to-b dark:from-zinc-950 dark:to-zinc-900">
         <div class="bg-background flex min-h-svh flex-col items-center justify-center gap-6 p-6 md:p-10">
             <div class="flex w-full max-w-sm flex-col gap-2">
                 <a href="{{ route('home') }}" class="flex flex-col items-center gap-2 font-medium" wire:navigate>
                     <span class="mb-1 flex h-9 w-9 items-center justify-center rounded-md">
-                        <x-app-logo-icon class="size-9 text-black dark:text-teal-500" />
+                        <x-app-logo-icon class="size-9 text-black dark:text-sky-500" />
                     </span>
                     <span class="sr-only">{{ config('app.name', 'WFM Toolkit') }}</span>
                 </a>

--- a/resources/views/components/layouts/auth/split.blade.php
+++ b/resources/views/components/layouts/auth/split.blade.php
@@ -3,14 +3,14 @@
     <head>
         @include('partials.head')
     </head>
-    <body class="min-h-screen bg-white antialiased dark:bg-linear-to-b dark:from-neutral-950 dark:to-neutral-900">
+    <body class="min-h-screen bg-white antialiased dark:bg-linear-to-b dark:from-zinc-950 dark:to-zinc-900">
         <div
             class="relative grid h-dvh flex-col items-center justify-center px-8 sm:px-0 lg:max-w-none lg:grid-cols-2 lg:px-0"
         >
             <div
-                class="relative hidden h-full flex-col bg-muted p-10 text-white lg:flex dark:border-r dark:border-neutral-800"
+                class="relative hidden h-full flex-col bg-muted p-10 text-white lg:flex dark:border-r dark:border-zinc-800"
             >
-                <div class="absolute inset-0 bg-neutral-900"></div>
+                <div class="absolute inset-0 bg-zinc-900"></div>
                 <a
                     href="{{ route('home') }}"
                     class="relative z-20 flex items-center text-lg font-medium"
@@ -29,7 +29,9 @@
                 <div class="relative z-20 mt-auto">
                     <blockquote class="space-y-2">
                         <flux:heading size="lg">&ldquo;{{ trim($message) }}&rdquo;</flux:heading>
-                        <footer><flux:heading>{{ trim($author) }}</flux:heading></footer>
+                        <footer>
+                            <flux:heading>{{ trim($author) }}</flux:heading>
+                        </footer>
                     </blockquote>
                 </div>
             </div>

--- a/resources/views/components/notification/card.blade.php
+++ b/resources/views/components/notification/card.blade.php
@@ -22,19 +22,19 @@
         'Critical' => 'red',
         'Success' => 'green',
         'Info' => 'blue',
-        default => 'gray',
+        default => 'zinc',
     };
 @endphp
 
 <div
-    {{ $attributes->merge(['class' => 'group block w-full cursor-pointer border-b border-gray-200 p-4 transition duration-150 ease-in-out hover:bg-gray-50 dark:border-gray-700 dark:hover:bg-gray-700']) }}
+    {{ $attributes->merge(['class' => 'group block w-full cursor-pointer border-b border-zinc-200 p-4 transition duration-150 ease-in-out hover:bg-zinc-50 dark:border-zinc-700 dark:hover:bg-zinc-700']) }}
 >
     <div class="flex items-start space-x-4">
         <div class="flex-shrink-0 pt-1">
             @if ($isUnread)
-                <span class="inline-block h-2 w-2 rounded-full bg-teal-500" title="Unread"></span>
+                <span class="inline-block h-2 w-2 rounded-full bg-sky-500" title="Unread"></span>
             @else
-                <span class="inline-block h-2 w-2 rounded-full bg-gray-300 dark:bg-gray-600" title="Read"></span>
+                <span class="inline-block h-2 w-2 rounded-full bg-zinc-300 dark:bg-zinc-600" title="Read"></span>
             @endif
         </div>
         <div class="min-w-0 flex-1">

--- a/resources/views/components/notification/details.blade.php
+++ b/resources/views/components/notification/details.blade.php
@@ -27,12 +27,12 @@
         'Warning' => 'orange',
         'Success' => 'green',
         'Info' => 'blue',
-        default => 'gray',
+        default => 'zinc',
     };
 @endphp
 
 <div
-    class="max-h-[calc(100vh-8rem)] overflow-y-auto rounded-lg border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-800"
+    class="max-h-[calc(100vh-8rem)] overflow-y-auto rounded-lg border border-zinc-200 bg-white p-4 dark:border-zinc-700 dark:bg-zinc-800"
 >
     {{-- Status and Message --}}
     <div class="mb-4">
@@ -40,11 +40,11 @@
             <flux:heading level="3" size="sm" class="mr-2">Status:</flux:heading>
             <flux:badge size="sm" variant="pill" :color="$badgeColor">{{ $status }}</flux:badge>
         </div>
-        <flux:text class="text-gray-600 dark:text-gray-300">{{ $message }}</flux:text>
+        <flux:text class="text-zinc-600 dark:text-zinc-300">{{ $message }}</flux:text>
     </div>
 
     {{-- Divider --}}
-    <div class="my-4 border-t dark:border-gray-600"></div>
+    <div class="my-4 border-t dark:border-zinc-600"></div>
 
     {{-- Known Place Notification Details --}}
     @if ($notificationType === 'known_place')

--- a/resources/views/components/notification/details/generic.blade.php
+++ b/resources/views/components/notification/details/generic.blade.php
@@ -16,17 +16,17 @@
 <div class="space-y-4">
     @if ($displayDetails->isNotEmpty())
         <div>
-            <flux:heading level="3" size="md" class="mb-3 border-b pb-2 dark:border-gray-600">
+            <flux:heading level="3" size="md" class="mb-3 border-b pb-2 dark:border-zinc-600">
                 Notification Details
             </flux:heading>
 
             <div class="space-y-2">
                 @foreach ($displayDetails as $key => $value)
                     <div class="text-sm">
-                        <span class="font-medium text-gray-700 capitalize dark:text-gray-300">
+                        <span class="font-medium text-zinc-700 capitalize dark:text-zinc-300">
                             {{ str_replace('_', ' ', $key) }}:
                         </span>
-                        <span class="text-gray-600 dark:text-gray-400">
+                        <span class="text-zinc-600 dark:text-zinc-400">
                             @if (is_array($value))
                                 @if (empty($value))
                                     <em>None</em>
@@ -63,12 +63,12 @@
 
     {{-- Show raw data in development environment --}}
     @if (config('app.debug') && ! empty($additionalDetails))
-        <div class="mt-6 border-t pt-4 dark:border-gray-600">
+        <div class="mt-6 border-t pt-4 dark:border-zinc-600">
             <details class="cursor-pointer">
-                <summary class="text-xs font-medium text-gray-500 dark:text-gray-400">
+                <summary class="text-xs font-medium text-zinc-500 dark:text-zinc-400">
                     Show Raw Notification Data (Debug)
                 </summary>
-                <pre class="mt-2 overflow-auto rounded bg-gray-100 p-2 text-xs dark:bg-gray-700">
+                <pre class="mt-2 overflow-auto rounded bg-zinc-100 p-2 text-xs dark:bg-zinc-700">
 {{ json_encode($details, JSON_PRETTY_PRINT) }}</pre
                 >
             </details>

--- a/resources/views/components/notification/details/known-ip-address.blade.php
+++ b/resources/views/components/notification/details/known-ip-address.blade.php
@@ -32,9 +32,9 @@
         @if ($startIp && $endIp)
             <flux:text>
                 <span class="font-medium">Range:</span>
-                <code class="rounded bg-gray-100 px-1 py-0.5 text-xs dark:bg-gray-700">{{ $startIp }}</code>
+                <code class="rounded bg-zinc-100 px-1 py-0.5 text-xs dark:bg-zinc-700">{{ $startIp }}</code>
                 to
-                <code class="rounded bg-gray-100 px-1 py-0.5 text-xs dark:bg-gray-700">{{ $endIp }}</code>
+                <code class="rounded bg-zinc-100 px-1 py-0.5 text-xs dark:bg-zinc-700">{{ $endIp }}</code>
             </flux:text>
         @endif
 
@@ -67,11 +67,11 @@
                         'critical' => 'red',
                         'warning' => 'orange',
                         'info' => 'blue',
-                        default => 'gray',
+                        default => 'zinc',
                     };
                 @endphp
 
-                <div class="rounded border border-gray-200 p-3 dark:border-gray-700">
+                <div class="rounded border border-zinc-200 p-3 dark:border-zinc-700">
                     <div class="mb-2 flex items-center justify-between">
                         <flux:text weight="medium" class="capitalize">
                             {{ str_replace('_', ' ', $issue['type'] ?? 'Unknown Issue') }}
@@ -81,17 +81,17 @@
                         </flux:badge>
                     </div>
 
-                    <flux:text class="text-sm text-gray-600 dark:text-gray-400">
+                    <flux:text class="text-sm text-zinc-600 dark:text-zinc-400">
                         {{ $issue['message'] ?? 'No details available.' }}
                     </flux:text>
 
                     {{-- Show overlapping ranges if available --}}
                     @if (isset($issue['overlapping_ranges']) && ! empty($issue['overlapping_ranges']))
                         <div class="mt-2">
-                            <flux:text class="text-xs font-medium text-gray-700 dark:text-gray-300">
+                            <flux:text class="text-xs font-medium text-zinc-700 dark:text-zinc-300">
                                 Overlapping with:
                             </flux:text>
-                            <ul class="mt-1 list-inside list-disc pl-4 text-xs text-gray-600 dark:text-gray-400">
+                            <ul class="mt-1 list-inside list-disc pl-4 text-xs text-zinc-600 dark:text-zinc-400">
                                 @foreach ($issue['overlapping_ranges'] as $id => $name)
                                     <li>{{ $name }} (ID: {{ $id }})</li>
                                 @endforeach
@@ -108,9 +108,9 @@
 
 {{-- Additional Information --}}
 @if ($startIp && $endIp)
-    <div class="mt-6 border-t pt-4 dark:border-gray-600">
+    <div class="mt-6 border-t pt-4 dark:border-zinc-600">
         <flux:heading level="4" size="sm" class="mb-2">Additional Information</flux:heading>
-        <div class="space-y-1 text-xs text-gray-600 dark:text-gray-400">
+        <div class="space-y-1 text-xs text-zinc-600 dark:text-zinc-400">
             @php
                 $startLong = ip2long($startIp);
                 $endLong = ip2long($endIp);
@@ -157,7 +157,7 @@
 
 {{-- Detail Actions --}}
 @if ($ipAddressId)
-    <div class="mt-6 border-t pt-4 dark:border-gray-600">
+    <div class="mt-6 border-t pt-4 dark:border-zinc-600">
         <flux:button
             href="{{ route('known-ip-addresses.edit', $ipAddressId) }}"
             target="_blank"

--- a/resources/views/components/notification/details/known-place.blade.php
+++ b/resources/views/components/notification/details/known-place.blade.php
@@ -1,4 +1,3 @@
-
 {{-- resources/views/components/notification/details/known-place.blade.php --}}
 
 @php
@@ -72,12 +71,12 @@
 @endif
 
 @if ($conflictingPlaces->isNotEmpty())
-    <flux:heading level="3" size="md" class="mt-6 mb-3 border-b pb-2 dark:border-gray-600">
+    <flux:heading level="3" size="md" class="mt-6 mb-3 border-b pb-2 dark:border-zinc-600">
         Conflicting Places
     </flux:heading>
     <div class="space-y-3">
         @foreach ($conflictingPlacesWithType as $place)
-            <div class="rounded border border-gray-200 p-3 dark:border-gray-700">
+            <div class="rounded border border-zinc-200 p-3 dark:border-zinc-700">
                 <div class="mb-1 flex items-center justify-between">
                     <flux:text weight="medium">
                         {{ $place['name'] ?? 'Unknown' }}
@@ -96,7 +95,7 @@
                         </flux:badge>
                     @endif
                 </div>
-                <ul class="mt-1 list-inside list-disc pl-4 text-sm text-gray-600 dark:text-gray-400">
+                <ul class="mt-1 list-inside list-disc pl-4 text-sm text-zinc-600 dark:text-zinc-400">
                     @forelse ($place['nodes'] ?? [] as $node)
                         <li>{{ $node['path'] ?? 'N/A' }} (Node ID: {{ $node['id'] ?? 'Unknown' }})</li>
                     @empty
@@ -116,7 +115,7 @@
 
 {{-- Detail Actions --}}
 @if ($triggeredPlace && isset($triggeredPlace['id']))
-    <div class="mt-6 border-t pt-4 dark:border-gray-600">
+    <div class="mt-6 border-t pt-4 dark:border-zinc-600">
         <flux:button
             href="{{ route('known-places.edit', $triggeredPlace['id']) }}"
             target="_blank"

--- a/resources/views/components/tools/api-explorer/adjustment-rules-table.blade.php
+++ b/resources/views/components/tools/api-explorer/adjustment-rules-table.blade.php
@@ -157,7 +157,7 @@
                                                 {{ implode(', ', array_slice($paycodes, 0, $displayLimit)) }}
                                                 <button
                                                     @click.stop="showAll = true"
-                                                    class="ml-1 text-teal-700 hover:text-teal-800 dark:text-teal-500 dark:hover:text-teal-700"
+                                                    class="ml-1 text-sky-700 hover:text-sky-800 dark:text-sky-500 dark:hover:text-sky-700"
                                                 >
                                                     (+{{ $paycode_count - $displayLimit }} more)
                                                 </button>
@@ -166,7 +166,7 @@
                                                 {{ $rule['paycode_names'] }}
                                                 <button
                                                     @click.stop="showAll = false"
-                                                    class="ml-1 text-teal-700 hover:text-teal-800 dark:text-teal-500 dark:hover:text-teal-700"
+                                                    class="ml-1 text-sky-700 hover:text-sky-800 dark:text-sky-500 dark:hover:text-sky-700"
                                                 >
                                                     (show less)
                                                 </button>

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -14,7 +14,7 @@
                 <div class="flex items-center justify-between">
                     <h2 class="text-lg font-semibold text-zinc-900 dark:text-white">Known Places</h2>
                     {{-- Count Badge --}}
-                    <flux:badge variant="solid" color="teal" class="inline-flex min-w-[2rem] justify-center">
+                    <flux:badge variant="solid" color="sky" class="inline-flex min-w-[2rem] justify-center">
                         {{ $user->known_places_count }}
                     </flux:badge>
                 </div>
@@ -49,7 +49,7 @@
                 <div class="flex items-center justify-between">
                     <h2 class="text-lg font-semibold text-zinc-900 dark:text-white">Known IP Addresses</h2>
                     {{-- Count Badge --}}
-                    <flux:badge variant="solid" color="teal" class="inline-flex min-w-[2rem] justify-center">
+                    <flux:badge variant="solid" color="sky" class="inline-flex min-w-[2rem] justify-center">
                         {{ $user->known_ip_addresses_count }}
                     </flux:badge>
                 </div>
@@ -76,7 +76,7 @@
             <div class="flex h-full flex-col overflow-hidden rounded-lg bg-white p-4 dark:bg-zinc-800">
                 <div class="flex items-center justify-between">
                     <h2 class="text-lg font-semibold text-zinc-900 dark:text-white">Locations</h2>
-                    <flux:badge variant="solid" color="teal" class="inline-flex min-w-[2rem] justify-center">
+                    <flux:badge variant="solid" color="sky" class="inline-flex min-w-[2rem] justify-center">
                         {{ $leafNodes->count() }}
                     </flux:badge>
                 </div>

--- a/resources/views/groups/show.blade.php
+++ b/resources/views/groups/show.blade.php
@@ -129,11 +129,7 @@
                         <div class="mb-6 rounded-lg bg-zinc-50 p-6 shadow-md dark:bg-zinc-700">
                             <div class="mb-4 flex items-center justify-between">
                                 <flux:heading level="2" size="lg">Known Places</flux:heading>
-                                <flux:badge
-                                    variant="solid"
-                                    color="teal"
-                                    class="inline-flex min-w-[2rem] justify-center"
-                                >
+                                <flux:badge variant="solid" color="sky" class="inline-flex min-w-[2rem] justify-center">
                                     {{ $group->knownPlaces->count() }}
                                 </flux:badge>
                             </div>
@@ -145,7 +141,7 @@
                                             <div class="flex items-center justify-between">
                                                 <div class="flex items-center">
                                                     <flux:icon.map-pin
-                                                        class="mr-2 size-4 text-teal-600 dark:text-teal-300"
+                                                        class="mr-2 size-4 text-sky-600 dark:text-sky-300"
                                                     />
                                                     <span class="font-medium text-zinc-700 dark:text-zinc-200">
                                                         {{ $knownPlace->name }}

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -40,7 +40,7 @@
                         </div>
                         <div class="p-6">
                             <div
-                                class="relative h-64 w-full overflow-hidden rounded-md bg-gradient-to-br from-slate-50 to-slate-100 lg:h-80 dark:from-zinc-800 dark:to-zinc-900"
+                                class="relative h-64 w-full overflow-hidden rounded-md bg-gradient-to-br from-zinc-50 to-zinc-100 lg:h-80 dark:from-zinc-800 dark:to-zinc-900"
                             >
                                 <!-- API Explorer mockup -->
                                 <div class="absolute inset-0 p-4 font-mono text-xs">
@@ -73,7 +73,7 @@
         <div class="mb-12 text-center">
             <flux:heading level="2" class="mb-4 text-3xl! tracking-tight">
                 Try Our Tools
-                <span class="block text-teal-700 dark:text-teal-500">No signup required</span>
+                <span class="block text-sky-700 dark:text-sky-500">No signup required</span>
             </flux:heading>
             <flux:text class="text-base md:text-lg">
                 Pro WFM tools that complement your daily workflow. Available instantly in your browser. No downloads
@@ -90,9 +90,9 @@
                     <div class="flex items-start space-x-4">
                         <div class="flex-shrink-0">
                             <div
-                                class="flex h-12 w-12 items-center justify-center rounded-lg bg-teal-100 dark:bg-teal-900"
+                                class="flex h-12 w-12 items-center justify-center rounded-lg bg-sky-100 dark:bg-sky-900"
                             >
-                                <flux:icon.map class="h-6 w-6 text-teal-600 dark:text-teal-400" />
+                                <flux:icon.map class="h-6 w-6 text-sky-600 dark:text-sky-400" />
                             </div>
                         </div>
                         <div class="flex-1">
@@ -206,9 +206,9 @@
         <div class="grid grid-cols-1 gap-6 md:grid-cols-3">
             <div class="text-center">
                 <div
-                    class="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-teal-100 dark:bg-teal-900"
+                    class="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-sky-100 dark:bg-sky-900"
                 >
-                    <flux:icon.bolt class="h-8 w-8 text-teal-600 dark:text-teal-400" />
+                    <flux:icon.bolt class="h-8 w-8 text-sky-600 dark:text-sky-400" />
                 </div>
                 <flux:heading level="3" size="lg" class="mb-2 font-semibold">Instant Access</flux:heading>
                 <flux:text class="text-sm">
@@ -245,7 +245,7 @@
 
     <!-- Call to Action -->
     <section class="mt-16 w-full">
-        <div class="rounded-lg bg-gradient-to-r from-teal-600 to-emerald-700 p-8 text-center">
+        <div class="rounded-lg bg-gradient-to-r from-sky-600 to-blue-800 p-8 text-center">
             <flux:heading level="2" class="mb-4 text-3xl! text-white">Ready to Get Started?</flux:heading>
             <flux:text class="text-lg text-white/90">
                 Try our tools now or create an account to save your work and access advanced features
@@ -271,7 +271,7 @@
     <!-- Powered By Section -->
     <section class="mt-16 w-full">
         <div
-            class="rounded-lg border border-zinc-200 bg-gradient-to-r from-zinc-50 to-zinc-100 p-8 dark:border-zinc-700 dark:from-zinc-800 dark:to-zinc-900"
+            class="rounded-lg border border-zinc-200 bg-transparent p-8 dark:border-zinc-700 dark:from-zinc-800 dark:to-zinc-900"
         >
             <div class="text-center">
                 <flux:heading level="3" class="mb-6 text-lg font-semibold text-zinc-700 dark:text-zinc-300">

--- a/resources/views/known-places/index.blade.php
+++ b/resources/views/known-places/index.blade.php
@@ -239,7 +239,7 @@
                                         <td class="px-6 py-4 whitespace-nowrap text-zinc-500 dark:text-zinc-400">
                                             @foreach ($place->validation_order as $method)
                                                 <flux:badge
-                                                    :color="$method === 'gps' ? 'teal' : 'blue'"
+                                                    :color="$method === 'gps' ? 'sky' : 'blue'"
                                                     class="inline-flex items-center text-xs"
                                                 >
                                                     {{ strtoupper($method) }}

--- a/resources/views/known-places/show.blade.php
+++ b/resources/views/known-places/show.blade.php
@@ -146,9 +146,7 @@
                                     @foreach ($knownPlace->nodes as $node)
                                         <div class="rounded-md bg-zinc-100 p-3 dark:bg-zinc-600">
                                             <div class="flex items-center">
-                                                <flux:icon.map-pin
-                                                    class="mr-2 size-5 text-teal-600 dark:text-teal-300"
-                                                />
+                                                <flux:icon.map-pin class="mr-2 size-5 text-sky-600 dark:text-sky-300" />
                                                 <span class="font-medium text-zinc-700 dark:text-zinc-200">
                                                     {{ $node->pivot->path ? $node->path : '' }}
                                                 </span>

--- a/resources/views/livewire/export-known-places.blade.php
+++ b/resources/views/livewire/export-known-places.blade.php
@@ -33,7 +33,7 @@
                         <ul class="space-y-3 text-sm">
                             <li class="flex items-start">
                                 <div
-                                    class="flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full bg-teal-600 text-xs font-medium text-zinc-900 dark:bg-teal-700 dark:text-white"
+                                    class="flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full bg-sky-600 text-xs font-medium text-zinc-900 dark:bg-sky-700 dark:text-white"
                                 >
                                     1
                                 </div>
@@ -43,7 +43,7 @@
                             </li>
                             <li class="flex items-start">
                                 <div
-                                    class="flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full bg-teal-600 text-xs font-medium text-zinc-900 dark:bg-teal-700 dark:text-white"
+                                    class="flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full bg-sky-600 text-xs font-medium text-zinc-900 dark:bg-sky-700 dark:text-white"
                                 >
                                     2
                                 </div>

--- a/resources/views/livewire/import-known-ip-addresses.blade.php
+++ b/resources/views/livewire/import-known-ip-addresses.blade.php
@@ -24,7 +24,7 @@
                         <ul class="space-y-3 text-sm">
                             <li class="flex items-start">
                                 <div
-                                    class="flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full bg-teal-300 text-xs font-medium text-zinc-900 dark:bg-teal-700 dark:text-white"
+                                    class="flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full bg-sky-300 text-xs font-medium text-zinc-900 dark:bg-sky-700 dark:text-white"
                                 >
                                     1
                                 </div>
@@ -32,7 +32,7 @@
                             </li>
                             <li class="flex items-start">
                                 <div
-                                    class="flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full bg-teal-300 text-xs font-medium text-zinc-900 dark:bg-teal-700 dark:text-white"
+                                    class="flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full bg-sky-300 text-xs font-medium text-zinc-900 dark:bg-sky-700 dark:text-white"
                                 >
                                     2
                                 </div>
@@ -40,7 +40,7 @@
                             </li>
                             <li class="flex items-start">
                                 <div
-                                    class="flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full bg-teal-300 text-xs font-medium text-zinc-900 dark:bg-teal-700 dark:text-white"
+                                    class="flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full bg-sky-300 text-xs font-medium text-zinc-900 dark:bg-sky-700 dark:text-white"
                                 >
                                     3
                                 </div>

--- a/resources/views/livewire/import-known-places.blade.php
+++ b/resources/views/livewire/import-known-places.blade.php
@@ -29,7 +29,7 @@
                         <ul class="space-y-3 text-sm">
                             <li class="flex items-start">
                                 <div
-                                    class="flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full bg-teal-600 text-xs font-medium text-zinc-900 dark:bg-teal-700 dark:text-white"
+                                    class="flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full bg-sky-600 text-xs font-medium text-zinc-900 dark:bg-sky-700 dark:text-white"
                                 >
                                     1
                                 </div>
@@ -37,7 +37,7 @@
                             </li>
                             <li class="flex items-start">
                                 <div
-                                    class="flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full bg-teal-600 text-xs font-medium text-zinc-900 dark:bg-teal-700 dark:text-white"
+                                    class="flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full bg-sky-600 text-xs font-medium text-zinc-900 dark:bg-sky-700 dark:text-white"
                                 >
                                     2
                                 </div>
@@ -45,7 +45,7 @@
                             </li>
                             <li class="flex items-start">
                                 <div
-                                    class="flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full bg-teal-600 text-xs font-medium text-zinc-900 dark:bg-teal-700 dark:text-white"
+                                    class="flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full bg-sky-600 text-xs font-medium text-zinc-900 dark:bg-sky-700 dark:text-white"
                                 >
                                     3
                                 </div>

--- a/resources/views/livewire/location-input.blade.php
+++ b/resources/views/livewire/location-input.blade.php
@@ -31,14 +31,14 @@
     </flux:field>
 
     {{-- Table displaying the added location paths --}}
-    <div class="mt-4 overflow-hidden rounded-lg border border-gray-700 shadow-sm">
+    <div class="mt-4 overflow-hidden rounded-lg border border-zinc-700 shadow-sm">
         <div class="max-h-64 overflow-y-auto">
-            <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
-                <thead class="sticky top-0 bg-gray-50 dark:bg-gray-800">
+            <table class="min-w-full divide-y divide-zinc-200 dark:divide-zinc-700">
+                <thead class="sticky top-0 bg-zinc-50 dark:bg-zinc-800">
                     <tr>
                         <th
                             scope="col"
-                            class="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-200"
+                            class="px-6 py-3 text-left text-xs font-medium tracking-wider text-zinc-500 uppercase dark:text-zinc-200"
                         >
                             Location Path
                         </th>
@@ -47,12 +47,12 @@
                         </th>
                     </tr>
                 </thead>
-                <tbody class="divide-y divide-gray-200 bg-white dark:divide-gray-700 dark:bg-gray-800">
+                <tbody class="divide-y divide-zinc-200 bg-white dark:divide-zinc-700 dark:bg-zinc-800">
                     {{-- $locations is an array of arrays --}}
                     @forelse ($locations as $index => $locationPathArray)
                         <tr wire:key="location-row-{{ $index }}">
                             {{-- Display the location path string by joining the array elements --}}
-                            <td class="px-6 py-4 text-sm whitespace-nowrap text-gray-900 dark:text-gray-100">
+                            <td class="px-6 py-4 text-sm whitespace-nowrap text-zinc-900 dark:text-zinc-100">
                                 {{ implode('/', $locationPathArray) }}
                                 @foreach ($locationPathArray as $segmentIndex => $segment)
                                     <input type="hidden" name="locations[{{ $index }}][]" value="{{ $segment }}" />
@@ -73,7 +73,7 @@
                         </tr>
                     @empty
                         <tr>
-                            <td colspan="2" class="px-6 py-4 text-center text-sm text-gray-500 dark:text-gray-400">
+                            <td colspan="2" class="px-6 py-4 text-center text-sm text-zinc-500 dark:text-zinc-400">
                                 No locations added yet.
                             </td>
                         </tr>

--- a/resources/views/livewire/notifications/actions.blade.php
+++ b/resources/views/livewire/notifications/actions.blade.php
@@ -1,11 +1,11 @@
-<div class="rounded-lg bg-white p-4 shadow-sm dark:bg-gray-800">
-    <flux:heading level="2" size="md" class="mb-3 border-b pb-2 dark:border-gray-700">Actions</flux:heading>
+<div class="rounded-lg bg-white p-4 shadow-sm dark:bg-zinc-800">
+    <flux:heading level="2" size="md" class="mb-3 border-b pb-2 dark:border-zinc-700">Actions</flux:heading>
     <div class="flex flex-col space-y-2">
         <form wire:submit="markAllAsRead">
             <flux:button
                 type="submit"
                 icon="eye"
-                class="flex w-full cursor-pointer items-center justify-start rounded-md p-2 text-gray-700 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-700"
+                class="flex w-full cursor-pointer items-center justify-start rounded-md p-2 text-zinc-700 hover:bg-zinc-100 dark:text-zinc-300 dark:hover:bg-zinc-700"
             >
                 Mark All as Read
             </flux:button>
@@ -14,7 +14,7 @@
             <flux:button
                 variant="danger"
                 icon="trash"
-                class="flex w-full cursor-pointer items-center justify-start rounded-md p-2 text-gray-700 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-700"
+                class="flex w-full cursor-pointer items-center justify-start rounded-md p-2 text-zinc-700 hover:bg-zinc-100 dark:text-zinc-300 dark:hover:bg-zinc-700"
             >
                 Delete All
             </flux:button>

--- a/resources/views/livewire/notifications/details.blade.php
+++ b/resources/views/livewire/notifications/details.blade.php
@@ -40,19 +40,19 @@
 @endphp
 
 <div
-    class="h-full overflow-y-auto rounded-lg border border-gray-200 bg-white p-4 shadow-sm dark:border-gray-700 dark:bg-gray-800"
+    class="h-full overflow-y-auto rounded-lg border border-zinc-200 bg-white p-4 shadow-sm dark:border-zinc-700 dark:bg-zinc-800"
 >
     {{-- Status and Message --}}
     <div class="mb-4">
         <flux:heading level="3" size="md" class="mb-2">Status: {{ $status }}</flux:heading>
-        <flux:text class="text-gray-600 dark:text-gray-300">{{ $message }}</flux:text>
+        <flux:text class="text-zinc-600 dark:text-zinc-300">{{ $message }}</flux:text>
     </div>
 
     {{-- Divider --}}
-    <div class="my-4 border-t dark:border-gray-600"></div>
+    <div class="my-4 border-t dark:border-zinc-600"></div>
 
     @if ($triggeredPlace)
-        <flux:heading level="3" size="md" class="mb-3 border-b pb-2 dark:border-gray-600">
+        <flux:heading level="3" size="md" class="mb-3 border-b pb-2 dark:border-zinc-600">
             Triggering Known Place: {{ $triggeredPlace['name'] ?? 'Unknown' }}
             @if (isset($triggeredPlace['id']))
                 (ID: {{ $triggeredPlace['id'] }})
@@ -73,19 +73,19 @@
     @endif
 
     @if (! empty($conflictingDescendants) | ! empty($conflictingAncestors))
-        <flux:heading level="3" size="md" class="mt-6 mb-3 border-b pb-2 dark:border-gray-600">
+        <flux:heading level="3" size="md" class="mt-6 mb-3 border-b pb-2 dark:border-zinc-600">
             Conflicting Places
         </flux:heading>
         <div class="space-y-3">
             @foreach ($conflictingDescendants as $place)
-                <div class="rounded border border-gray-200 p-3 dark:border-gray-700">
+                <div class="rounded border border-zinc-200 p-3 dark:border-zinc-700">
                     <flux:text weight="medium">
                         {{ $place['name'] ?? 'Unknown' }}
                         @if (isset($place['id']))
                             (ID: {{ $place['id'] }})
                         @endif
                     </flux:text>
-                    <ul class="mt-1 list-inside list-disc pl-4 text-sm text-gray-600 dark:text-gray-400">
+                    <ul class="mt-1 list-inside list-disc pl-4 text-sm text-zinc-600 dark:text-zinc-400">
                         @forelse ($place['nodes'] ?? [] as $node)
                             <li>{{ $node['path'] ?? 'N/A' }} (Node ID: {{ $node['id'] ?? 'Unknown' }})</li>
                         @empty
@@ -98,19 +98,19 @@
     @endif
 
     @if (! empty($conflictingAncestors))
-        <flux:heading level="3" size="md" class="mt-6 mb-3 border-b pb-2 dark:border-gray-600">
+        <flux:heading level="3" size="md" class="mt-6 mb-3 border-b pb-2 dark:border-zinc-600">
             Conflicting Ancestor Places
         </flux:heading>
         <div class="space-y-3">
             @foreach ($conflictingAncestors as $place)
-                <div class="rounded border border-gray-200 p-3 dark:border-gray-700">
+                <div class="rounded border border-zinc-200 p-3 dark:border-zinc-700">
                     <flux:text weight="medium">
                         {{ $place['name'] ?? 'Unknown' }}
                         @if (isset($place['id']))
                             (ID: {{ $place['id'] }})
                         @endif
                     </flux:text>
-                    <ul class="mt-1 list-inside list-disc pl-4 text-sm text-gray-600 dark:text-gray-400">
+                    <ul class="mt-1 list-inside list-disc pl-4 text-sm text-zinc-600 dark:text-zinc-400">
                         @forelse ($place['nodes'] ?? [] as $node)
                             <li>{{ $node['path'] ?? 'N/A' }} (Node ID: {{ $node['id'] ?? 'Unknown' }})</li>
                         @empty
@@ -123,7 +123,7 @@
     @endif
 
     @if (empty($conflictingDescendants) && empty($conflictingAncestors) && $triggeredPlace === null)
-        <div class="mt-6 rounded-md bg-gray-50 p-4 dark:bg-gray-700">
+        <div class="mt-6 rounded-md bg-zinc-50 p-4 dark:bg-zinc-700">
             <flux:text variant="subtle" class="text-center">
                 @if ($status !== 'Notification')
                     No specific conflicting places identified for this status.
@@ -136,7 +136,7 @@
 
     {{-- Add relevant action buttons here if desired, e.g., link to edit the KnownPlace --}}
     @if ($triggeredPlace && isset($triggeredPlace['id']))
-        <div class="mt-6 border-t pt-4 dark:border-gray-600">
+        <div class="mt-6 border-t pt-4 dark:border-zinc-600">
             <flux:button
                 :href="route('known-places.edit', $triggeredPlace['id'])"
                 target="_blank"
@@ -147,7 +147,7 @@
             </flux:button>
         </div>
     @elseif (isset($details['known_place_id']))
-        <div class="mt-6 border-t pt-4 dark:border-gray-600">
+        <div class="mt-6 border-t pt-4 dark:border-zinc-600">
             <flux:button
                 :href="route('known-places.edit', $details['known_place_id'])"
                 target="_blank"

--- a/resources/views/livewire/notifications/filters.blade.php
+++ b/resources/views/livewire/notifications/filters.blade.php
@@ -1,7 +1,7 @@
 <div class="space-y-6">
     {{-- Filter: Read/Unread --}}
-    <div class="rounded-lg bg-white p-4 dark:bg-gray-800">
-        <flux:heading level="2" size="md" class="mb-3 border-b pb-2 dark:border-gray-700">
+    <div class="rounded-lg bg-white p-4 dark:bg-zinc-800">
+        <flux:heading level="2" size="md" class="mb-3 border-b pb-2 dark:border-zinc-700">
             Filter Notifications
         </flux:heading>
         <div class="flex flex-col space-y-2">
@@ -27,8 +27,8 @@
     </div>
 
     {{-- Filter: Severity Levels --}}
-    <div class="rounded-lg bg-white p-4 dark:bg-gray-800">
-        <flux:heading level="2" size="md" class="mb-3 border-b pb-2 dark:border-gray-700">Severity Levels</flux:heading>
+    <div class="rounded-lg bg-white p-4 dark:bg-zinc-800">
+        <flux:heading level="2" size="md" class="mb-3 border-b pb-2 dark:border-zinc-700">Severity Levels</flux:heading>
         <div class="flex flex-col space-y-2">
             <x-filter-button query="status" filter="all" :is-active="$currentStatus === 'all'">
                 <x-slot:icon>
@@ -56,7 +56,7 @@
             </x-filter-button>
             <x-filter-button query="status" filter="notification" :is-active="$currentStatus === 'notification'">
                 <x-slot:icon>
-                    <flux:icon.bell class="size-5 text-gray-500" variant="solid" />
+                    <flux:icon.bell class="size-5 text-zinc-500" variant="solid" />
                 </x-slot>
                 General
             </x-filter-button>

--- a/resources/views/livewire/notifications/notification-center.blade.php
+++ b/resources/views/livewire/notifications/notification-center.blade.php
@@ -55,9 +55,9 @@
 
         <!-- Notification List -->
         <div class="lg:col-span-2">
-            <div class="overflow-hidden rounded-lg bg-white dark:bg-gray-800">
+            <div class="overflow-hidden rounded-lg bg-white dark:bg-zinc-800">
                 {{-- Header for the list --}}
-                <div class="border-b border-gray-200 p-4 dark:border-gray-700">
+                <div class="border-b border-zinc-200 p-4 dark:border-zinc-700">
                     <div class="flex items-center justify-between">
                         <div>
                             @if ($this->status && $this->status !== 'all')
@@ -108,14 +108,14 @@
                             wire:click="selectNotification('{{ $notification->id }}')"
                             wire:navigate
                             @class([
-                                'bg-teal-50 dark:bg-teal-900/50 border-l-4 border-teal-500' => $selectedNotificationId === $notification->id,
+                                'bg-sky-50 dark:bg-sky-900/50 border-l-4 border-sky-500' => $selectedNotificationId === $notification->id,
                                 'border-l-4 border-transparent' => $selectedNotificationId !== $notification->id,
                             ])
                         />
                     @empty
                         <div class="flex flex-col items-center justify-center p-12 text-center">
                             @if ($this->filter !== 'all' || $this->status !== 'all')
-                                <flux:icon.bell-slash class="size-10 text-gray-400 dark:text-gray-600" />
+                                <flux:icon.bell-slash class="size-10 text-zinc-400 dark:text-zinc-600" />
                                 <flux:text variant="subtle" size="lg" class="mt-4">
                                     No notifications match the current filters.
                                 </flux:text>
@@ -123,7 +123,7 @@
                                     Try adjusting or clearing the filters.
                                 </flux:text>
                             @else
-                                <flux:icon.bell class="size-10 text-gray-400 dark:text-gray-600" />
+                                <flux:icon.bell class="size-10 text-zinc-400 dark:text-zinc-600" />
                                 <flux:text variant="subtle" size="lg" class="mt-4">No notifications found.</flux:text>
                             @endif
                         </div>
@@ -132,7 +132,7 @@
 
                 {{-- Pagination --}}
                 @if ($this->notifications->hasPages())
-                    <div class="border-t border-gray-200 bg-gray-50 px-4 py-3 dark:border-gray-700 dark:bg-gray-900">
+                    <div class="border-t border-zinc-200 bg-zinc-50 px-4 py-3 dark:border-zinc-700 dark:bg-zinc-900">
                         <div class="flex items-center justify-between">
                             <div class="flex items-center gap-2">
                                 <flux:text size="sm" variant="subtle">
@@ -198,7 +198,7 @@
                 <x-notification.details :details="$selectedNotificationData" />
             @else
                 <div
-                    class="flex h-64 items-center justify-center rounded-lg border-2 border-dashed border-gray-300 bg-white p-6 text-center text-gray-500 dark:border-gray-700 dark:bg-gray-800"
+                    class="flex h-64 items-center justify-center rounded-lg border-2 border-dashed border-zinc-300 bg-white p-6 text-center text-zinc-500 dark:border-zinc-700 dark:bg-zinc-800"
                 >
                     Select a notification from the list to view its details.
                 </div>

--- a/resources/views/livewire/tools/api-explorer/endpoints/labor-categories-paginated-list.blade.php
+++ b/resources/views/livewire/tools/api-explorer/endpoints/labor-categories-paginated-list.blade.php
@@ -18,7 +18,7 @@
                         <select
                             wire:model.live="selectedLaborCategories"
                             multiple
-                            class="{{ ! $isAuthenticated || empty($laborCategories) ? 'opacity-50' : '' }} min-h-[120px] w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none dark:border-gray-600 dark:bg-gray-800 dark:text-white"
+                            class="{{ ! $isAuthenticated || empty($laborCategories) ? 'opacity-50' : '' }} min-h-[120px] w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none dark:border-zinc-600 dark:bg-zinc-800 dark:text-white"
                             {{ ! $isAuthenticated || empty($laborCategories) ? 'disabled' : '' }}
                         >
                             @if ($isAuthenticated && ! empty($laborCategories))
@@ -63,7 +63,7 @@
                             @foreach ($selectedLaborCategories as $selected)
                                 <span
                                     wire:key="selected-labor-category-{{ $selected }}"
-                                    class="inline-flex items-center gap-1 rounded-md bg-gray-100 px-2 py-1 text-xs font-medium text-gray-700 dark:bg-gray-700/50 dark:text-gray-300"
+                                    class="inline-flex items-center gap-1 rounded-md bg-zinc-100 px-2 py-1 text-xs font-medium text-zinc-700 dark:bg-zinc-700/50 dark:text-zinc-300"
                                 >
                                     {{ $selected }}
                                     <button

--- a/resources/views/livewire/tools/api-explorer/raw-json-viewer.blade.php
+++ b/resources/views/livewire/tools/api-explorer/raw-json-viewer.blade.php
@@ -34,8 +34,8 @@
             <div class="relative p-4">
                 @if ($isLoading)
                     <div class="flex items-center justify-center py-8">
-                        <flux:icon.loading class="h-6 w-6 animate-spin text-gray-400" />
-                        <span class="ml-2 text-sm text-gray-500">Loading JSON data...</span>
+                        <flux:icon.loading class="h-6 w-6 animate-spin text-zinc-400" />
+                        <span class="ml-2 text-sm text-zinc-500">Loading JSON data...</span>
                     </div>
                 @elseif ($errorMessage)
                     <div class="rounded-lg border border-red-200 bg-red-50 p-4 dark:border-red-800 dark:bg-red-900/20">

--- a/resources/views/livewire/tools/har-analyzer/tabs/domains.blade.php
+++ b/resources/views/livewire/tools/har-analyzer/tabs/domains.blade.php
@@ -73,7 +73,7 @@
                 <div
                     @class([
                         'flex h-12 w-12 items-center justify-center rounded-lg',
-                        'bg-gray-100 dark:bg-gray-900/30' => $envType === 'local',
+                        'bg-zinc-100 dark:bg-zinc-900/30' => $envType === 'local',
                         'bg-purple-100 dark:bg-purple-900/30' => $envType === 'development',
                         'bg-orange-100 dark:bg-orange-900/30' => $envType === 'staging',
                         'bg-green-100 dark:bg-green-900/30' => $envType === 'production',
@@ -83,7 +83,7 @@
                         name="{{ $envIcon }}"
                         @class([
                             'h-6 w-6',
-                            'text-gray-600 dark:text-gray-400' => $envType === 'local',
+                            'text-zinc-600 dark:text-zinc-400' => $envType === 'local',
                             'text-purple-600 dark:text-purple-400' => $envType === 'development',
                             'text-orange-600 dark:text-orange-400' => $envType === 'staging',
                             'text-green-600 dark:text-green-400' => $envType === 'production',
@@ -268,7 +268,7 @@
                                 str_contains($domainName, 'jsdelivr') || str_contains($domainName, 'unpkg') => ['name' => 'CDN', 'type' => 'Content Delivery', 'color' => 'green'],
                                 str_contains($domainName, 'youtube') || str_contains($domainName, 'youtu.be') => ['name' => 'YouTube', 'type' => 'Video/Media', 'color' => 'red'],
                                 str_contains($domainName, 'twitter') || str_contains($domainName, 'twimg') => ['name' => 'Twitter', 'type' => 'Social Media', 'color' => 'blue'],
-                                default => ['name' => 'Unknown Service', 'type' => 'Third-Party', 'color' => 'gray'],
+                                default => ['name' => 'Unknown Service', 'type' => 'Third-Party', 'color' => 'zinc'],
                             };
                             return array_merge($domain, $service);
                         })

--- a/resources/views/livewire/tools/har-analyzer/tabs/requests.blade.php
+++ b/resources/views/livewire/tools/har-analyzer/tabs/requests.blade.php
@@ -147,7 +147,7 @@
                                     'bg-yellow-500' => ($method ?? '') === 'PUT',
                                     'bg-red-500' => ($method ?? '') === 'DELETE',
                                     'bg-purple-500' => ($method ?? '') === 'PATCH',
-                                    'bg-gray-500' => ! in_array($method ?? '', ['GET', 'POST', 'PUT', 'DELETE', 'PATCH']),
+                                    'bg-zinc-500' => ! in_array($method ?? '', ['GET', 'POST', 'PUT', 'DELETE', 'PATCH']),
                                 ])
                             ></div>
 
@@ -263,7 +263,7 @@
                                         'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300' => ($resource['method'] ?? '') === 'DELETE',
                                         'bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-300' =>
                                             ($resource['method'] ?? '') === 'PATCH',
-                                        'bg-gray-100 text-gray-800 dark:bg-gray-900/30 dark:text-gray-300' => ! in_array($resource['method'] ?? '', [
+                                        'bg-zinc-100 text-zinc-800 dark:bg-zinc-900/30 dark:text-zinc-300' => ! in_array($resource['method'] ?? '', [
                                             'GET',
                                             'POST',
                                             'PUT',

--- a/resources/views/locations/show.blade.php
+++ b/resources/views/locations/show.blade.php
@@ -3,21 +3,21 @@
         <h1 class="mb-6 text-3xl font-bold">{{ $node->name }}</h1>
 
         {{-- Display node details if needed --}}
-        <div class="mb-8 rounded-lg bg-white p-6 shadow dark:bg-gray-800">
-            <h2 class="mb-4 text-xl font-semibold text-gray-800 dark:text-gray-200">Location Details</h2>
-            <p class="text-gray-600 dark:text-gray-400">
-                <span class="font-medium text-gray-700 dark:text-gray-300">Full Path:</span>
+        <div class="mb-8 rounded-lg bg-white p-6 shadow dark:bg-zinc-800">
+            <h2 class="mb-4 text-xl font-semibold text-zinc-800 dark:text-zinc-200">Location Details</h2>
+            <p class="text-zinc-600 dark:text-zinc-400">
+                <span class="font-medium text-zinc-700 dark:text-zinc-300">Full Path:</span>
                 {{ $node->path }}
             </p>
             {{-- Add more node details here as required --}}
         </div>
 
         {{-- Section for Known Places --}}
-        <div class="rounded-lg bg-white p-6 shadow dark:bg-gray-800">
-            <h2 class="mb-4 text-xl font-semibold text-gray-800 dark:text-gray-200">Associated Known Places</h2>
+        <div class="rounded-lg bg-white p-6 shadow dark:bg-zinc-800">
+            <h2 class="mb-4 text-xl font-semibold text-zinc-800 dark:text-zinc-200">Associated Known Places</h2>
 
             @if ($node->knownPlaces->isNotEmpty())
-                <ul class="list-inside list-disc space-y-2 text-gray-600 dark:text-gray-400">
+                <ul class="list-inside list-disc space-y-2 text-zinc-600 dark:text-zinc-400">
                     @foreach ($node->knownPlaces as $knownPlace)
                         <li>
                             {{-- Link to the Known Place's show page --}}
@@ -28,13 +28,13 @@
                                 {{ $knownPlace->name }}
                             </a>
                             {{-- Display other KnownPlace details if needed --}}
-                            {{-- e.g., <span class="text-sm text-gray-500">({{ $knownPlace->description }})</span> --}}
+                            {{-- e.g., <span class="text-sm text-zinc-500">({{ $knownPlace->description }})</span> --}}
                         </li>
                     @endforeach
                 </ul>
                 {{ $knownPlaces->links() }}
             @else
-                <p class="text-gray-500 dark:text-gray-400">
+                <p class="text-zinc-500 dark:text-zinc-400">
                     No Known Places are currently associated with this location.
                 </p>
             @endif

--- a/resources/views/vendor/pagination/bootstrap-4.blade.php
+++ b/resources/views/vendor/pagination/bootstrap-4.blade.php
@@ -1,0 +1,46 @@
+@if ($paginator->hasPages())
+    <nav>
+        <ul class="pagination">
+            {{-- Previous Page Link --}}
+            @if ($paginator->onFirstPage())
+                <li class="page-item disabled" aria-disabled="true" aria-label="@lang('pagination.previous')">
+                    <span class="page-link" aria-hidden="true">&lsaquo;</span>
+                </li>
+            @else
+                <li class="page-item">
+                    <a class="page-link" href="{{ $paginator->previousPageUrl() }}" rel="prev" aria-label="@lang('pagination.previous')">&lsaquo;</a>
+                </li>
+            @endif
+
+            {{-- Pagination Elements --}}
+            @foreach ($elements as $element)
+                {{-- "Three Dots" Separator --}}
+                @if (is_string($element))
+                    <li class="page-item disabled" aria-disabled="true"><span class="page-link">{{ $element }}</span></li>
+                @endif
+
+                {{-- Array Of Links --}}
+                @if (is_array($element))
+                    @foreach ($element as $page => $url)
+                        @if ($page == $paginator->currentPage())
+                            <li class="page-item active" aria-current="page"><span class="page-link">{{ $page }}</span></li>
+                        @else
+                            <li class="page-item"><a class="page-link" href="{{ $url }}">{{ $page }}</a></li>
+                        @endif
+                    @endforeach
+                @endif
+            @endforeach
+
+            {{-- Next Page Link --}}
+            @if ($paginator->hasMorePages())
+                <li class="page-item">
+                    <a class="page-link" href="{{ $paginator->nextPageUrl() }}" rel="next" aria-label="@lang('pagination.next')">&rsaquo;</a>
+                </li>
+            @else
+                <li class="page-item disabled" aria-disabled="true" aria-label="@lang('pagination.next')">
+                    <span class="page-link" aria-hidden="true">&rsaquo;</span>
+                </li>
+            @endif
+        </ul>
+    </nav>
+@endif

--- a/resources/views/vendor/pagination/bootstrap-5.blade.php
+++ b/resources/views/vendor/pagination/bootstrap-5.blade.php
@@ -1,0 +1,88 @@
+@if ($paginator->hasPages())
+    <nav class="d-flex justify-items-center justify-content-between">
+        <div class="d-flex justify-content-between flex-fill d-sm-none">
+            <ul class="pagination">
+                {{-- Previous Page Link --}}
+                @if ($paginator->onFirstPage())
+                    <li class="page-item disabled" aria-disabled="true">
+                        <span class="page-link">@lang('pagination.previous')</span>
+                    </li>
+                @else
+                    <li class="page-item">
+                        <a class="page-link" href="{{ $paginator->previousPageUrl() }}" rel="prev">@lang('pagination.previous')</a>
+                    </li>
+                @endif
+
+                {{-- Next Page Link --}}
+                @if ($paginator->hasMorePages())
+                    <li class="page-item">
+                        <a class="page-link" href="{{ $paginator->nextPageUrl() }}" rel="next">@lang('pagination.next')</a>
+                    </li>
+                @else
+                    <li class="page-item disabled" aria-disabled="true">
+                        <span class="page-link">@lang('pagination.next')</span>
+                    </li>
+                @endif
+            </ul>
+        </div>
+
+        <div class="d-none flex-sm-fill d-sm-flex align-items-sm-center justify-content-sm-between">
+            <div>
+                <p class="small text-muted">
+                    {!! __('Showing') !!}
+                    <span class="fw-semibold">{{ $paginator->firstItem() }}</span>
+                    {!! __('to') !!}
+                    <span class="fw-semibold">{{ $paginator->lastItem() }}</span>
+                    {!! __('of') !!}
+                    <span class="fw-semibold">{{ $paginator->total() }}</span>
+                    {!! __('results') !!}
+                </p>
+            </div>
+
+            <div>
+                <ul class="pagination">
+                    {{-- Previous Page Link --}}
+                    @if ($paginator->onFirstPage())
+                        <li class="page-item disabled" aria-disabled="true" aria-label="@lang('pagination.previous')">
+                            <span class="page-link" aria-hidden="true">&lsaquo;</span>
+                        </li>
+                    @else
+                        <li class="page-item">
+                            <a class="page-link" href="{{ $paginator->previousPageUrl() }}" rel="prev" aria-label="@lang('pagination.previous')">&lsaquo;</a>
+                        </li>
+                    @endif
+
+                    {{-- Pagination Elements --}}
+                    @foreach ($elements as $element)
+                        {{-- "Three Dots" Separator --}}
+                        @if (is_string($element))
+                            <li class="page-item disabled" aria-disabled="true"><span class="page-link">{{ $element }}</span></li>
+                        @endif
+
+                        {{-- Array Of Links --}}
+                        @if (is_array($element))
+                            @foreach ($element as $page => $url)
+                                @if ($page == $paginator->currentPage())
+                                    <li class="page-item active" aria-current="page"><span class="page-link">{{ $page }}</span></li>
+                                @else
+                                    <li class="page-item"><a class="page-link" href="{{ $url }}">{{ $page }}</a></li>
+                                @endif
+                            @endforeach
+                        @endif
+                    @endforeach
+
+                    {{-- Next Page Link --}}
+                    @if ($paginator->hasMorePages())
+                        <li class="page-item">
+                            <a class="page-link" href="{{ $paginator->nextPageUrl() }}" rel="next" aria-label="@lang('pagination.next')">&rsaquo;</a>
+                        </li>
+                    @else
+                        <li class="page-item disabled" aria-disabled="true" aria-label="@lang('pagination.next')">
+                            <span class="page-link" aria-hidden="true">&rsaquo;</span>
+                        </li>
+                    @endif
+                </ul>
+            </div>
+        </div>
+    </nav>
+@endif

--- a/resources/views/vendor/pagination/default.blade.php
+++ b/resources/views/vendor/pagination/default.blade.php
@@ -1,0 +1,46 @@
+@if ($paginator->hasPages())
+    <nav>
+        <ul class="pagination">
+            {{-- Previous Page Link --}}
+            @if ($paginator->onFirstPage())
+                <li class="disabled" aria-disabled="true" aria-label="@lang('pagination.previous')">
+                    <span aria-hidden="true">&lsaquo;</span>
+                </li>
+            @else
+                <li>
+                    <a href="{{ $paginator->previousPageUrl() }}" rel="prev" aria-label="@lang('pagination.previous')">&lsaquo;</a>
+                </li>
+            @endif
+
+            {{-- Pagination Elements --}}
+            @foreach ($elements as $element)
+                {{-- "Three Dots" Separator --}}
+                @if (is_string($element))
+                    <li class="disabled" aria-disabled="true"><span>{{ $element }}</span></li>
+                @endif
+
+                {{-- Array Of Links --}}
+                @if (is_array($element))
+                    @foreach ($element as $page => $url)
+                        @if ($page == $paginator->currentPage())
+                            <li class="active" aria-current="page"><span>{{ $page }}</span></li>
+                        @else
+                            <li><a href="{{ $url }}">{{ $page }}</a></li>
+                        @endif
+                    @endforeach
+                @endif
+            @endforeach
+
+            {{-- Next Page Link --}}
+            @if ($paginator->hasMorePages())
+                <li>
+                    <a href="{{ $paginator->nextPageUrl() }}" rel="next" aria-label="@lang('pagination.next')">&rsaquo;</a>
+                </li>
+            @else
+                <li class="disabled" aria-disabled="true" aria-label="@lang('pagination.next')">
+                    <span aria-hidden="true">&rsaquo;</span>
+                </li>
+            @endif
+        </ul>
+    </nav>
+@endif

--- a/resources/views/vendor/pagination/semantic-ui.blade.php
+++ b/resources/views/vendor/pagination/semantic-ui.blade.php
@@ -1,0 +1,36 @@
+@if ($paginator->hasPages())
+    <div class="ui pagination menu" role="navigation">
+        {{-- Previous Page Link --}}
+        @if ($paginator->onFirstPage())
+            <a class="icon item disabled" aria-disabled="true" aria-label="@lang('pagination.previous')"> <i class="left chevron icon"></i> </a>
+        @else
+            <a class="icon item" href="{{ $paginator->previousPageUrl() }}" rel="prev" aria-label="@lang('pagination.previous')"> <i class="left chevron icon"></i> </a>
+        @endif
+
+        {{-- Pagination Elements --}}
+        @foreach ($elements as $element)
+            {{-- "Three Dots" Separator --}}
+            @if (is_string($element))
+                <a class="icon item disabled" aria-disabled="true">{{ $element }}</a>
+            @endif
+
+            {{-- Array Of Links --}}
+            @if (is_array($element))
+                @foreach ($element as $page => $url)
+                    @if ($page == $paginator->currentPage())
+                        <a class="item active" href="{{ $url }}" aria-current="page">{{ $page }}</a>
+                    @else
+                        <a class="item" href="{{ $url }}">{{ $page }}</a>
+                    @endif
+                @endforeach
+            @endif
+        @endforeach
+
+        {{-- Next Page Link --}}
+        @if ($paginator->hasMorePages())
+            <a class="icon item" href="{{ $paginator->nextPageUrl() }}" rel="next" aria-label="@lang('pagination.next')"> <i class="right chevron icon"></i> </a>
+        @else
+            <a class="icon item disabled" aria-disabled="true" aria-label="@lang('pagination.next')"> <i class="right chevron icon"></i> </a>
+        @endif
+    </div>
+@endif

--- a/resources/views/vendor/pagination/simple-bootstrap-4.blade.php
+++ b/resources/views/vendor/pagination/simple-bootstrap-4.blade.php
@@ -1,0 +1,27 @@
+@if ($paginator->hasPages())
+    <nav>
+        <ul class="pagination">
+            {{-- Previous Page Link --}}
+            @if ($paginator->onFirstPage())
+                <li class="page-item disabled" aria-disabled="true">
+                    <span class="page-link">@lang('pagination.previous')</span>
+                </li>
+            @else
+                <li class="page-item">
+                    <a class="page-link" href="{{ $paginator->previousPageUrl() }}" rel="prev">@lang('pagination.previous')</a>
+                </li>
+            @endif
+
+            {{-- Next Page Link --}}
+            @if ($paginator->hasMorePages())
+                <li class="page-item">
+                    <a class="page-link" href="{{ $paginator->nextPageUrl() }}" rel="next">@lang('pagination.next')</a>
+                </li>
+            @else
+                <li class="page-item disabled" aria-disabled="true">
+                    <span class="page-link">@lang('pagination.next')</span>
+                </li>
+            @endif
+        </ul>
+    </nav>
+@endif

--- a/resources/views/vendor/pagination/simple-bootstrap-5.blade.php
+++ b/resources/views/vendor/pagination/simple-bootstrap-5.blade.php
@@ -1,0 +1,29 @@
+@if ($paginator->hasPages())
+    <nav role="navigation" aria-label="Pagination Navigation">
+        <ul class="pagination">
+            {{-- Previous Page Link --}}
+            @if ($paginator->onFirstPage())
+                <li class="page-item disabled" aria-disabled="true">
+                    <span class="page-link">{!! __('pagination.previous') !!}</span>
+                </li>
+            @else
+                <li class="page-item">
+                    <a class="page-link" href="{{ $paginator->previousPageUrl() }}" rel="prev">
+                        {!! __('pagination.previous') !!}
+                    </a>
+                </li>
+            @endif
+
+            {{-- Next Page Link --}}
+            @if ($paginator->hasMorePages())
+                <li class="page-item">
+                    <a class="page-link" href="{{ $paginator->nextPageUrl() }}" rel="next">{!! __('pagination.next') !!}</a>
+                </li>
+            @else
+                <li class="page-item disabled" aria-disabled="true">
+                    <span class="page-link">{!! __('pagination.next') !!}</span>
+                </li>
+            @endif
+        </ul>
+    </nav>
+@endif

--- a/resources/views/vendor/pagination/simple-default.blade.php
+++ b/resources/views/vendor/pagination/simple-default.blade.php
@@ -1,0 +1,19 @@
+@if ($paginator->hasPages())
+    <nav>
+        <ul class="pagination">
+            {{-- Previous Page Link --}}
+            @if ($paginator->onFirstPage())
+                <li class="disabled" aria-disabled="true"><span>@lang('pagination.previous')</span></li>
+            @else
+                <li><a href="{{ $paginator->previousPageUrl() }}" rel="prev">@lang('pagination.previous')</a></li>
+            @endif
+
+            {{-- Next Page Link --}}
+            @if ($paginator->hasMorePages())
+                <li><a href="{{ $paginator->nextPageUrl() }}" rel="next">@lang('pagination.next')</a></li>
+            @else
+                <li class="disabled" aria-disabled="true"><span>@lang('pagination.next')</span></li>
+            @endif
+        </ul>
+    </nav>
+@endif

--- a/resources/views/vendor/pagination/simple-tailwind.blade.php
+++ b/resources/views/vendor/pagination/simple-tailwind.blade.php
@@ -1,0 +1,37 @@
+@if ($paginator->hasPages())
+    <nav role="navigation" aria-label="Pagination Navigation" class="flex justify-between">
+        {{-- Previous Page Link --}}
+        @if ($paginator->onFirstPage())
+            <span
+                class="relative inline-flex cursor-default items-center rounded-md border border-zinc-300 bg-white px-4 py-2 text-sm leading-5 font-medium text-zinc-500 dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-600"
+            >
+                {!! __('pagination.previous') !!}
+            </span>
+        @else
+            <a
+                href="{{ $paginator->previousPageUrl() }}"
+                rel="prev"
+                class="relative inline-flex items-center rounded-md border border-zinc-300 bg-white px-4 py-2 text-sm leading-5 font-medium text-zinc-700 ring-zinc-300 transition duration-150 ease-in-out hover:text-zinc-500 focus:border-blue-300 focus:ring focus:outline-none active:bg-zinc-100 active:text-zinc-700 dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-300 dark:focus:border-blue-700 dark:active:bg-zinc-700 dark:active:text-zinc-300"
+            >
+                {!! __('pagination.previous') !!}
+            </a>
+        @endif
+
+        {{-- Next Page Link --}}
+        @if ($paginator->hasMorePages())
+            <a
+                href="{{ $paginator->nextPageUrl() }}"
+                rel="next"
+                class="relative inline-flex items-center rounded-md border border-zinc-300 bg-white px-4 py-2 text-sm leading-5 font-medium text-zinc-700 ring-zinc-300 transition duration-150 ease-in-out hover:text-zinc-500 focus:border-blue-300 focus:ring focus:outline-none active:bg-zinc-100 active:text-zinc-700 dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-300 dark:focus:border-blue-700 dark:active:bg-zinc-700 dark:active:text-zinc-300"
+            >
+                {!! __('pagination.next') !!}
+            </a>
+        @else
+            <span
+                class="relative inline-flex cursor-default items-center rounded-md border border-zinc-300 bg-white px-4 py-2 text-sm leading-5 font-medium text-zinc-500 dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-600"
+            >
+                {!! __('pagination.next') !!}
+            </span>
+        @endif
+    </nav>
+@endif

--- a/resources/views/vendor/pagination/tailwind.blade.php
+++ b/resources/views/vendor/pagination/tailwind.blade.php
@@ -1,0 +1,162 @@
+@if ($paginator->hasPages())
+    <nav role="navigation" aria-label="{{ __('Pagination Navigation') }}" class="flex items-center justify-between">
+        <div class="flex flex-1 justify-between sm:hidden">
+            @if ($paginator->onFirstPage())
+                <span
+                    class="relative inline-flex cursor-default items-center rounded-md border border-zinc-300 bg-white px-4 py-2 text-sm leading-5 font-medium text-zinc-500 dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-600"
+                >
+                    {!! __('pagination.previous') !!}
+                </span>
+            @else
+                <a
+                    href="{{ $paginator->previousPageUrl() }}"
+                    class="relative inline-flex items-center rounded-md border border-zinc-300 bg-white px-4 py-2 text-sm leading-5 font-medium text-zinc-700 ring-zinc-300 transition duration-150 ease-in-out hover:text-zinc-500 focus:border-sky-300 focus:ring focus:outline-none active:bg-zinc-100 active:text-zinc-700 dark:border-zinc-600 dark:bg-sky-800 dark:text-zinc-300 dark:focus:border-sky-700 dark:active:bg-zinc-700 dark:active:text-zinc-300"
+                >
+                    {!! __('pagination.previous') !!}
+                </a>
+            @endif
+
+            @if ($paginator->hasMorePages())
+                <a
+                    href="{{ $paginator->nextPageUrl() }}"
+                    class="relative ml-3 inline-flex items-center rounded-md border border-zinc-300 bg-white px-4 py-2 text-sm leading-5 font-medium text-zinc-700 ring-zinc-300 transition duration-150 ease-in-out hover:text-zinc-500 focus:border-sky-300 focus:ring focus:outline-none active:bg-zinc-100 active:text-zinc-700 dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-300 dark:focus:border-sky-700 dark:active:bg-zinc-700 dark:active:text-zinc-300"
+                >
+                    {!! __('pagination.next') !!}
+                </a>
+            @else
+                <span
+                    class="relative ml-3 inline-flex cursor-default items-center rounded-md border border-zinc-300 bg-white px-4 py-2 text-sm leading-5 font-medium text-zinc-500 dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-600"
+                >
+                    {!! __('pagination.next') !!}
+                </span>
+            @endif
+        </div>
+
+        <div class="hidden sm:flex sm:flex-1 sm:items-center sm:justify-between">
+            <div>
+                <p class="text-sm leading-5 text-zinc-700 dark:text-zinc-400">
+                    {!! __('Showing') !!}
+                    @if ($paginator->firstItem())
+                        <span class="font-medium">{{ $paginator->firstItem() }}</span>
+                        {!! __('to') !!}
+                        <span class="font-medium">{{ $paginator->lastItem() }}</span>
+                    @else
+                        {{ $paginator->count() }}
+                    @endif
+                    {!! __('of') !!}
+                    <span class="font-medium">{{ $paginator->total() }}</span>
+                    {!! __('results') !!}
+                </p>
+            </div>
+
+            <div>
+                <span class="relative z-0 inline-flex rounded-md shadow-sm rtl:flex-row-reverse">
+                    {{-- Previous Page Link --}}
+
+                    @if ($paginator->onFirstPage())
+                        <span aria-disabled="true" aria-label="{{ __('pagination.previous') }}">
+                            <span
+                                class="relative inline-flex cursor-default items-center rounded-l-md border border-zinc-300 bg-white px-2 py-2 text-sm leading-5 font-medium text-zinc-500 dark:border-zinc-600 dark:bg-zinc-800"
+                                aria-hidden="true"
+                            >
+                                <svg class="h-5 w-5" viewBox="0 0 20 20">
+                                    <path
+                                        fill-rule="evenodd"
+                                        d="M12.707 5.293a1 1 0 010 1.414L9.414 10l3.293 3.293a1 1 0 01-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z"
+                                        clip-rule="evenodd"
+                                    />
+                                </svg>
+                            </span>
+                        </span>
+                    @else
+                        <a
+                            href="{{ $paginator->previousPageUrl() }}"
+                            rel="prev"
+                            class="relative inline-flex items-center rounded-l-md border border-zinc-300 bg-white px-2 py-2 text-sm leading-5 font-medium text-zinc-500 ring-zinc-300 transition duration-150 ease-in-out hover:text-zinc-400 focus:z-10 focus:border-sky-300 focus:ring focus:outline-none active:bg-zinc-100 active:text-zinc-500 dark:border-zinc-600 dark:bg-zinc-800 dark:focus:border-sky-800 dark:active:bg-zinc-700"
+                            aria-label="{{ __('pagination.previous') }}"
+                        >
+                            <svg class="h-5 w-5" viewBox="0 0 20 20">
+                                <path
+                                    fill-rule="evenodd"
+                                    d="M12.707 5.293a1 1 0 010 1.414L9.414 10l3.293 3.293a1 1 0 01-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z"
+                                    clip-rule="evenodd"
+                                />
+                            </svg>
+                        </a>
+                    @endif
+
+                    {{-- Pagination Elements --}}
+                    @foreach ($elements as $element)
+                        {{-- "Three Dots" Separator --}}
+                        @if (is_string($element))
+                            <span aria-disabled="true">
+                                <span
+                                    class="relative -ml-px inline-flex cursor-default items-center border border-zinc-300 bg-white px-4 py-2 text-sm leading-5 font-medium text-zinc-500 dark:border-zinc-600 dark:bg-zinc-800"
+                                >
+                                    {{ $element }}
+                                </span>
+                            </span>
+                        @endif
+
+                        {{-- Array Of Links --}}
+                        @if (is_array($element))
+                            @foreach ($element as $page => $url)
+                                @if ($page == $paginator->currentPage())
+                                    <span aria-current="page">
+                                        <span
+                                            class="relative -ml-px inline-flex cursor-default items-center border border-zinc-300 bg-white px-4 py-2 text-sm leading-5 font-medium text-zinc-500 dark:border-zinc-600 dark:bg-zinc-800"
+                                        >
+                                            {{ $page }}
+                                        </span>
+                                    </span>
+                                @else
+                                    <a
+                                        href="{{ $url }}"
+                                        class="relative -ml-px inline-flex items-center border border-zinc-300 bg-white px-4 py-2 text-sm leading-5 font-medium text-zinc-700 ring-zinc-300 transition duration-150 ease-in-out hover:text-zinc-500 focus:z-10 focus:border-sky-300 focus:ring focus:outline-none active:bg-zinc-100 active:text-zinc-700 dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-400 dark:hover:text-zinc-300 dark:focus:border-sky-800 dark:active:bg-zinc-700"
+                                        aria-label="{{ __('Go to page :page', ['page' => $page]) }}"
+                                    >
+                                        {{ $page }}
+                                    </a>
+                                @endif
+                            @endforeach
+                        @endif
+                    @endforeach
+
+                    {{-- Next Page Link --}}
+
+                    @if ($paginator->hasMorePages())
+                        <a
+                            href="{{ $paginator->nextPageUrl() }}"
+                            rel="next"
+                            class="relative -ml-px inline-flex items-center rounded-r-md border border-zinc-300 bg-white px-2 py-2 text-sm leading-5 font-medium text-zinc-500 ring-zinc-300 transition duration-150 ease-in-out hover:text-zinc-400 focus:z-10 focus:border-sky-300 focus:ring focus:outline-none active:bg-zinc-100 active:text-zinc-500 dark:border-zinc-600 dark:bg-zinc-800 dark:focus:border-sky-800 dark:active:bg-zinc-700"
+                            aria-label="{{ __('pagination.next') }}"
+                        >
+                            <svg class="h-5 w-5" viewBox="0 0 20 20">
+                                <path
+                                    fill-rule="evenodd"
+                                    d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
+                                    clip-rule="evenodd"
+                                />
+                            </svg>
+                        </a>
+                    @else
+                        <span aria-disabled="true" aria-label="{{ __('pagination.next') }}">
+                            <span
+                                class="relative -ml-px inline-flex cursor-default items-center rounded-r-md border border-zinc-300 bg-white px-2 py-2 text-sm leading-5 font-medium text-zinc-500 dark:border-zinc-600 dark:bg-zinc-800"
+                                aria-hidden="true"
+                            >
+                                <svg class="h-5 w-5" viewBox="0 0 20 20">
+                                    <path
+                                        fill-rule="evenodd"
+                                        d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
+                                        clip-rule="evenodd"
+                                    />
+                                </svg>
+                            </span>
+                        </span>
+                    @endif
+                </span>
+            </div>
+        </div>
+    </nav>
+@endif

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -1,7 +1,7 @@
 <x-layouts.app :title="__('Welcome to WFM Toolkit')">
     <div class="container mx-auto max-w-4xl px-4 py-12">
         <div class="text-center">
-            <flux:icon.map-pin class="mx-auto mb-4 size-12 text-teal-500" />
+            <flux:icon.map-pin class="mx-auto mb-4 size-12 text-sky-500" />
             <flux:heading size="xl" level="1" class="mb-1 font-bold! text-shadow-lg/30!">
                 Welcome to the WFM Toolkit!
             </flux:heading>
@@ -63,7 +63,7 @@
                 <ol class="space-y-6">
                     <li class="flex items-start">
                         <div
-                            class="mr-4 flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-teal-700 text-white"
+                            class="mr-4 flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-sky-700 text-white"
                         >
                             1
                         </div>
@@ -81,7 +81,7 @@
                     </li>
                     <li class="flex items-start">
                         <div
-                            class="mr-4 flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-teal-700 text-white"
+                            class="mr-4 flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-sky-700 text-white"
                         >
                             2
                         </div>
@@ -103,7 +103,7 @@
                     </li>
                     <li class="flex items-start">
                         <div
-                            class="mr-4 flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-teal-700 text-white"
+                            class="mr-4 flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-sky-700 text-white"
                         >
                             3
                         </div>
@@ -119,7 +119,7 @@
                     </li>
                     <li class="flex items-start">
                         <div
-                            class="mr-4 flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-teal-700 text-white"
+                            class="mr-4 flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-sky-700 text-white"
                         >
                             4
                         </div>
@@ -138,7 +138,7 @@
                     </li>
                     <li class="flex items-start">
                         <div
-                            class="mr-4 flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-teal-700 text-white"
+                            class="mr-4 flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-sky-700 text-white"
                         >
                             5
                         </div>


### PR DESCRIPTION
Unified the application's color scheme by replacing all instances of `teal` with `sky` and `gray` with `zinc`. Updated views, components, and styles to ensure consistency.