### PR TITLE
Add percent allocation rules UI and related fixes

### DIFF
--- a/app/Livewire/Tools/ApiExplorer/Endpoints/PercentAllocationRulesList.php
+++ b/app/Livewire/Tools/ApiExplorer/Endpoints/PercentAllocationRulesList.php
@@ -1,0 +1,433 @@
+<?php
+
+namespace App\Livewire\Tools\ApiExplorer\Endpoints;
+
+use App\Livewire\Tools\ApiExplorer\BaseApiEndpoint;
+use App\Traits\ExportsCsvData;
+use App\Traits\PaginatesApiData;
+use Exception;
+use Illuminate\Contracts\View\View;
+use Illuminate\Http\Client\Response;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Log;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+class PercentAllocationRulesList extends BaseApiEndpoint
+{
+    use ExportsCsvData;
+    use PaginatesApiData;
+
+    public function render(): View
+    {
+        $paginatedData = $this->getPaginatedData();
+
+        return view('livewire.tools.api-explorer.endpoints.percent-allocation-rules-list', [
+            'paginatedData' => $paginatedData,
+        ]);
+    }
+
+    /**
+     * Override exportAllToCsv to use flattened data structure
+     */
+    public function exportAllToCsv(): StreamedResponse|RedirectResponse
+    {
+        try {
+            $allData = $this->getAllDataForExport();
+
+            if ($allData->isEmpty()) {
+                session()?->flash('error', 'No data available to export.');
+
+                return back();
+            }
+
+            // Apply current search and sort filters
+            $filteredData = $this->applyFiltersAndSort($allData);
+
+            // Flatten the data for CSV export
+            $flattenedData = $this->flattenPercentAllocationRulesForCsv($filteredData);
+
+            $filename = $this->generateExportFilename('all');
+
+            return $this->generateCsv($flattenedData, $this->defineCSVColumnsForTheFlattenedData(), $filename);
+        } catch (Exception $e) {
+            Log::error('CSV Export Error - All Data', [
+                'error' => $e->getMessage(),
+                'component' => get_class($this),
+            ]);
+
+            session()?->flash('error', 'Failed to export data. Please try again.');
+
+            return back();
+        }
+    }
+
+    /**
+     * Custom method for getting all data for export - required by ExportsCsvData trait
+     */
+    protected function getAllDataForExport(): Collection
+    {
+        $response = $this->fetchData();
+
+        if (! $response || ! $response->successful()) {
+            return collect();
+        }
+
+        $allData = $this->extractDataFromResponse($response);
+
+        // Process the data to add custom fields
+        $processedData = $this->processDataForDisplay($allData);
+
+        return collect($processedData);
+    }
+
+    /**
+     * Fetches data by making an authenticated API call to retrieve percent allocation rules.
+     */
+    protected function fetchData(): ?Response
+    {
+        return $this->makeAuthenticatedApiCall(function () {
+            return $this->wfmService->getPercentAllocationRules();
+        });
+    }
+
+    /**
+     * Process raw API data to add custom fields
+     */
+    protected function processDataForDisplay(array $data): array
+    {
+        return array_map(function ($item) {
+            $item['job_names'] = $this->extractJobNames($item);
+            $item['paycode_names'] = $this->extractPaycodeNames($item);
+
+            return $item;
+        }, $data);
+    }
+
+    /**
+     * Extract job names from allocations for the main table display
+     */
+    private function extractJobNames($item): string
+    {
+        $jobNames = [];
+
+        // Navigate through the nested structure to get job names
+        $fpaRuleVersions = $item['fpaRuleVersions'] ?? [];
+
+        foreach ($fpaRuleVersions as $ruleVersion) {
+            $triggers = $ruleVersion['triggers'] ?? [];
+
+            foreach ($triggers as $trigger) {
+                $allocations = $trigger['allocations'] ?? [];
+
+                foreach ($allocations as $allocation) {
+                    $job = $allocation['job'] ?? [];
+                    if (isset($job['name'])) {
+                        $jobNames[] = $job['name'];
+                    } elseif (isset($job['qualifier'])) {
+                        $jobNames[] = $job['qualifier'];
+                    }
+                }
+            }
+        }
+
+        // Remove duplicates and return as comma-separated string
+        $uniqueNames = array_unique($jobNames);
+
+        return implode(', ', $uniqueNames);
+    }
+
+    /**
+     * Extract paycode names from triggers for the main table display
+     */
+    private function extractPaycodeNames($item): string
+    {
+        $paycodeNames = [];
+
+        // Navigate through the nested structure to get paycodes
+        $fpaRuleVersions = $item['fpaRuleVersions'] ?? [];
+
+        foreach ($fpaRuleVersions as $ruleVersion) {
+            $triggers = $ruleVersion['triggers'] ?? [];
+
+            foreach ($triggers as $trigger) {
+                $payCodes = $trigger['payCodes'] ?? [];
+                foreach ($payCodes as $payCode) {
+                    if (isset($payCode['qualifier'])) {
+                        $paycodeNames[] = $payCode['qualifier'];
+                    }
+                }
+            }
+        }
+
+        // Remove duplicates and return as comma-separated string
+        $uniqueNames = array_unique($paycodeNames);
+
+        return implode(', ', $uniqueNames);
+    }
+
+    /**
+     * Flatten the nested percent allocation rules data structure for CSV export
+     */
+    private function flattenPercentAllocationRulesForCsv($data): array
+    {
+        $flattened = [];
+
+        foreach ($data as $rule) {
+            $ruleId = $rule['id'] ?? '';
+            $ruleName = $rule['name'] ?? 'Unnamed Rule';
+            $persistentId = $rule['persistentId'] ?? '';
+            $jobNames = $rule['job_names'] ?? '-';
+            $paycodeNames = $rule['paycode_names'] ?? '-';
+
+            $fpaRuleVersions = $rule['fpaRuleVersions'] ?? [];
+
+            // If no versions exist, create a single row with rule-level data
+            if (empty($fpaRuleVersions)) {
+                $flattened[] = [
+                    'rule_id' => $ruleId,
+                    'rule_name' => $ruleName,
+                    'persistent_id' => $persistentId,
+                    'job_names' => $jobNames,
+                    'paycode_names' => $paycodeNames,
+                    'version_description' => '',
+                    'start_effective_date' => '',
+                    'end_effective_date' => '',
+                    'trigger_index' => '',
+                    'job_or_location_qualifier' => '',
+                    'job_or_location_effective_date' => '',
+                    'labor_category_entries' => '',
+                    'trigger_pay_codes' => '',
+                    'allocation_index' => '',
+                    'allocation_percentage' => '',
+                    'wage_adjustment_amount' => '',
+                    'wage_adjustment_type' => '',
+                    'allocation_job_name' => '',
+                    'allocation_job_qualifier' => '',
+                ];
+
+                continue;
+            }
+
+            foreach ($fpaRuleVersions as $version) {
+                $versionDescription = $version['description'] ?? '';
+                $startEffectiveDate = $version['startEffectiveDate'] ?? '';
+                $endEffectiveDate = $version['endEffectiveDate'] ?? '';
+
+                $triggers = $version['triggers'] ?? [];
+
+                // If no triggers exist, create a single row with version-level data
+                if (empty($triggers)) {
+                    $flattened[] = [
+                        'rule_id' => $ruleId,
+                        'rule_name' => $ruleName,
+                        'persistent_id' => $persistentId,
+                        'job_names' => $jobNames,
+                        'paycode_names' => $paycodeNames,
+                        'version_description' => $versionDescription,
+                        'start_effective_date' => $startEffectiveDate,
+                        'end_effective_date' => $endEffectiveDate,
+                        'trigger_index' => '',
+                        'job_or_location_qualifier' => '',
+                        'job_or_location_effective_date' => '',
+                        'labor_category_entries' => '',
+                        'trigger_pay_codes' => '',
+                        'allocation_index' => '',
+                        'allocation_percentage' => '',
+                        'wage_adjustment_amount' => '',
+                        'wage_adjustment_type' => '',
+                        'allocation_job_name' => '',
+                        'allocation_job_qualifier' => '',
+                    ];
+
+                    continue;
+                }
+
+                // Process each trigger
+                foreach ($triggers as $triggerIndex => $trigger) {
+                    // Extract trigger data
+                    $jobOrLocationQualifier = $trigger['jobOrLocation']['qualifier'] ?? '';
+                    $jobOrLocationEffectiveDate = $trigger['jobOrLocationEffectiveDate'] ?? '';
+                    $laborCategoryEntries = $trigger['laborCategoryEntries'] ?? '';
+
+                    // Extract pay codes
+                    $payCodes = $trigger['payCodes'] ?? [];
+                    $triggerPayCodes = collect($payCodes)
+                        ->pluck('qualifier')
+                        ->filter()
+                        ->implode(', ');
+
+                    $allocations = $trigger['allocations'] ?? [];
+
+                    // If no allocations exist, create a single row with trigger-level data
+                    if (empty($allocations)) {
+                        $flattened[] = [
+                            'rule_id' => $ruleId,
+                            'rule_name' => $ruleName,
+                            'persistent_id' => $persistentId,
+                            'job_names' => $jobNames,
+                            'paycode_names' => $paycodeNames,
+                            'version_description' => $versionDescription,
+                            'start_effective_date' => $startEffectiveDate,
+                            'end_effective_date' => $endEffectiveDate,
+                            'trigger_index' => $triggerIndex + 1,
+                            'job_or_location_qualifier' => $jobOrLocationQualifier,
+                            'job_or_location_effective_date' => $jobOrLocationEffectiveDate,
+                            'labor_category_entries' => $laborCategoryEntries,
+                            'trigger_pay_codes' => $triggerPayCodes ?: '-',
+                            'allocation_index' => '',
+                            'allocation_percentage' => '',
+                            'wage_adjustment_amount' => '',
+                            'wage_adjustment_type' => '',
+                            'allocation_job_name' => '',
+                            'allocation_job_qualifier' => '',
+                        ];
+
+                        continue;
+                    }
+
+                    // Process each allocation
+                    foreach ($allocations as $allocationIndex => $allocation) {
+                        $flattened[] = [
+                            'rule_id' => $ruleId,
+                            'rule_name' => $ruleName,
+                            'persistent_id' => $persistentId,
+                            'job_names' => $jobNames,
+                            'paycode_names' => $paycodeNames,
+                            'version_description' => $versionDescription,
+                            'start_effective_date' => $startEffectiveDate,
+                            'end_effective_date' => $endEffectiveDate,
+                            'trigger_index' => $triggerIndex + 1,
+                            'job_or_location_qualifier' => $jobOrLocationQualifier,
+                            'job_or_location_effective_date' => $jobOrLocationEffectiveDate,
+                            'labor_category_entries' => $laborCategoryEntries,
+                            'trigger_pay_codes' => $triggerPayCodes ?: '-',
+                            'allocation_index' => $allocationIndex + 1,
+                            'allocation_percentage' => $allocation['percentage'] ?? '',
+                            'wage_adjustment_amount' => $allocation['wageAdjustmentAmount'] ?? '',
+                            'wage_adjustment_type' => $allocation['wageAdjustmentType'] ?? '',
+                            'allocation_job_name' => $allocation['job']['name'] ?? '',
+                            'allocation_job_qualifier' => $allocation['job']['qualifier'] ?? '',
+                        ];
+                    }
+                }
+            }
+        }
+
+        return $flattened;
+    }
+
+    /**
+     * Custom filename generation for exports
+     */
+    protected function generateExportFilename(string $type): string
+    {
+        $parts = ['percent-allocation-rules', $type];
+
+        // Add search term if present
+        if (! empty($this->search)) {
+            $searchSlug = str_replace([' ', '.', '/', '\\'], '-', strtolower($this->search));
+            $parts[] = "search-{$searchSlug}";
+        }
+
+        // Add timestamp
+        $parts[] = now()->format('Y-m-d_H-i-s');
+
+        return implode('-', $parts);
+    }
+
+    /**
+     * Define CSV columns for the flattened data
+     */
+    private function defineCSVColumnsForTheFlattenedData(): array
+    {
+        return [
+            ['field' => 'rule_id', 'label' => 'Rule ID'],
+            ['field' => 'rule_name', 'label' => 'Rule Name'],
+            ['field' => 'persistent_id', 'label' => 'Persistent ID'],
+            ['field' => 'job_names', 'label' => 'Job Names'],
+            ['field' => 'paycode_names', 'label' => 'Pay Code Names'],
+            ['field' => 'version_description', 'label' => 'Version Description'],
+            ['field' => 'start_effective_date', 'label' => 'Start Effective Date'],
+            ['field' => 'end_effective_date', 'label' => 'End Effective Date'],
+            ['field' => 'trigger_index', 'label' => 'Trigger Index'],
+            ['field' => 'job_or_location_qualifier', 'label' => 'Job/Location Qualifier'],
+            ['field' => 'job_or_location_effective_date', 'label' => 'Job/Location Effective Date'],
+            ['field' => 'labor_category_entries', 'label' => 'Labor Category Entries'],
+            ['field' => 'trigger_pay_codes', 'label' => 'Trigger Pay Codes'],
+            ['field' => 'allocation_index', 'label' => 'Allocation Index'],
+            ['field' => 'allocation_percentage', 'label' => 'Allocation Percentage'],
+            ['field' => 'wage_adjustment_amount', 'label' => 'Wage Adjustment Amount'],
+            ['field' => 'wage_adjustment_type', 'label' => 'Wage Adjustment Type'],
+            ['field' => 'allocation_job_name', 'label' => 'Allocation Job Name'],
+            ['field' => 'allocation_job_qualifier', 'label' => 'Allocation Job Qualifier'],
+        ];
+    }
+
+    /**
+     * Override exportSelectionsToCsv to use flattened data structure
+     */
+    public function exportSelectionsToCsv(): StreamedResponse|RedirectResponse
+    {
+        try {
+            $exportData = $this->getAllData();
+            $filteredData = $this->applyFiltersAndSort($exportData);
+
+            if ($filteredData->isEmpty()) {
+                session()?->flash('error', 'No data available to export.');
+
+                return back();
+            }
+
+            // Flatten the data for CSV export
+            $flattenedData = $this->flattenPercentAllocationRulesForCsv($filteredData);
+
+            $filename = $this->generateExportFilename('selections');
+
+            return $this->generateCsv($flattenedData, $this->defineCSVColumnsForTheFlattenedData(), $filename);
+        } catch (Exception $e) {
+            Log::error('CSV Export Error - Selections', [
+                'error' => $e->getMessage(),
+                'component' => get_class($this),
+            ]);
+
+            session()?->flash('error', 'Failed to export CSV. Please try again.');
+
+            return back();
+        }
+    }
+
+    /**
+     * Initialize endpoint configuration
+     */
+    protected function initializeEndpoint(): void
+    {
+        $this->tableColumns = [
+            ['field' => 'name', 'label' => 'Name'],
+            ['field' => 'fpaRuleVersions.0.description', 'label' => 'Description'],
+            ['field' => 'fpaRuleVersions.0.startEffectiveDate', 'label' => 'Start Date'],
+            ['field' => 'fpaRuleVersions.0.endEffectiveDate', 'label' => 'End Date'],
+            ['field' => 'job_names', 'label' => 'Jobs'],
+            ['field' => 'paycode_names', 'label' => 'Pay Codes'],
+        ];
+
+        $this->initializePaginationData();
+    }
+
+    /**
+     * Override the storeData method to include custom processing
+     */
+    protected function storeData(array $data): void
+    {
+        // Process data to add custom fields
+        $processedData = $this->processDataForDisplay($data);
+
+        $this->tableData = $processedData;
+        $this->totalRecords = count($processedData);
+
+        // Cache the processed data
+        if (! empty($this->cacheKey)) {
+            cache()->put($this->cacheKey, collect($processedData), now()->addMinutes(30));
+        }
+    }
+}

--- a/app/Services/WfmService.php
+++ b/app/Services/WfmService.php
@@ -543,6 +543,19 @@ class WfmService
     }
 
     /**
+     * @throws \Illuminate\Http\Client\ConnectionException
+     * @throws \JsonException
+     */
+    public function getPercentAllocationRules(array $requestData = []): Response
+    {
+        // Add all_details flag to true to get more information
+        return $this->callWfmApi(
+            'GET',
+            'api/v1/timekeeping/setup/percentage_allocation_rules?all_details=true',
+        );
+    }
+
+    /**
      * Retrieve paginated data elements from the WFM API.
      *
      * @param  array  $requestData  Optional parameters for filtering or

--- a/resources/views/components/tools/api-explorer/adjustment-rules-table.blade.php
+++ b/resources/views/components/tools/api-explorer/adjustment-rules-table.blade.php
@@ -96,7 +96,7 @@
                     $ruleVersions = $rule['ruleVersions']['adjustmentRuleVersion'] ?? [];
                     $firstVersion = $ruleVersions[0] ?? null;
                     $newestVersion = end($ruleVersions);
-                    $ruleId = $rule['id'] ?? uniqid();
+                    $ruleId = $rule['id'] ?? '';
                 @endphp
 
                 <div
@@ -147,7 +147,7 @@
                                     $paycodes = explode(', ', $rule['paycode_names'] ?? '');
                                     $displayLimit = 3;
                                     $paycode_count = count($paycodes);
-                                    $ruleId = $rule['id'] ?? uniqid();
+                                    $ruleId = $rule['id'] ?? '';
                                 @endphp
 
                                 <div x-data="{ showAll: false }">

--- a/resources/views/components/tools/api-explorer/percent-allocation-rules-cards.blade.php
+++ b/resources/views/components/tools/api-explorer/percent-allocation-rules-cards.blade.php
@@ -1,0 +1,426 @@
+@props([
+    'paginatedData' => null,
+    'title' => 'Percent Allocation Rules',
+    'totalRecords' => 0,
+    'showBorder' => true,
+    'search' => '',
+    'sortField' => '',
+    'sortDirection' => 'asc',
+    'perPage' => 15,
+])
+
+<div
+    @class([
+        'border-t border-zinc-200 pt-6 dark:border-zinc-700' => $showBorder,
+        'space-y-4',
+    ])
+    x-data="{
+        expandedRules: {},
+        expandAll: false,
+        toggleRule(ruleId) {
+            this.expandedRules[ruleId] = ! this.expandedRules[ruleId]
+        },
+        toggleAll() {
+            this.expandAll = ! this.expandAll
+            Object.keys(this.expandedRules).forEach((key) => {
+                this.expandedRules[key] = this.expandAll
+            })
+        },
+    }"
+>
+    <!-- Header -->
+    <div class="flex flex-col space-y-3 md:flex-row md:items-center md:justify-between md:space-y-0">
+        <flux:heading size="md">{{ $title }} ({{ $totalRecords }} total)</flux:heading>
+
+        <div class="flex flex-col space-y-2 sm:flex-row sm:items-center sm:space-y-0 sm:space-x-2">
+            <flux:button @click="toggleAll()" variant="ghost" size="sm" class="w-full sm:w-auto">
+                <span x-text="expandAll ? 'Collapse All' : 'Expand All'"></span>
+            </flux:button>
+
+            <div class="flex space-x-2">
+                <flux:button
+                    wire:click="exportAllToCsv"
+                    variant="subtle"
+                    size="sm"
+                    icon="arrow-down-tray"
+                    class="flex-1 sm:flex-none"
+                >
+                    <span class="hidden sm:inline">Export All (CSV)</span>
+                    <span class="sm:hidden">Export All</span>
+                </flux:button>
+                <flux:button
+                    wire:click="exportSelectionsToCsv"
+                    variant="subtle"
+                    size="sm"
+                    icon="arrow-down-tray"
+                    class="flex-1 sm:flex-none"
+                >
+                    <span class="hidden sm:inline">Export Selections (CSV)</span>
+                    <span class="sm:hidden">Export Selections</span>
+                </flux:button>
+            </div>
+        </div>
+    </div>
+
+    <!-- Search and Controls -->
+    <div class="flex items-center justify-between space-x-4">
+        <div class="max-w-md flex-1 text-sm md:text-base">
+            <flux:input
+                wire:model.live.debounce.300ms="search"
+                placeholder="Search percent allocation rules..."
+                class:input="text-sm md:text-base"
+                icon="magnifying-glass"
+            />
+        </div>
+
+        <div class="flex items-center space-x-2">
+            <flux:text size="sm" variant="subtle">Show:</flux:text>
+            <select
+                wire:model.live="perPage"
+                class="rounded-md border border-zinc-300 px-2 py-1 text-sm dark:border-zinc-600 dark:bg-zinc-800"
+            >
+                <option value="10">10</option>
+                <option value="15">15</option>
+                <option value="25">25</option>
+                <option value="50">50</option>
+                <option value="100">100</option>
+            </select>
+        </div>
+    </div>
+
+    <!-- Rules List -->
+    <div class="space-y-4">
+        @if ($paginatedData && $paginatedData->count() > 0)
+            @foreach ($paginatedData->items() as $rule)
+                @php
+                    $fpaRuleVersions = $rule['fpaRuleVersions'] ?? [];
+                    $firstVersion = $fpaRuleVersions[0] ?? null;
+                    $newestVersion = end($fpaRuleVersions);
+                    $ruleId = $rule['id'] ?? null;
+                @endphp
+
+                <div
+                    class="rounded-lg border border-zinc-200 bg-white shadow-sm dark:border-zinc-700 dark:bg-zinc-800"
+                    x-init="expandedRules['{{ $ruleId }}'] = false"
+                >
+                    <!-- Rule Header -->
+                    <div
+                        class="flex cursor-pointer items-center justify-between p-4 hover:bg-zinc-50 dark:hover:bg-zinc-700/50"
+                        @click="toggleRule('{{ $ruleId }}')"
+                    >
+                        <div class="min-w-0 flex-1">
+                            <div class="flex items-center space-x-3">
+                                <flux:icon.chevron-right
+                                    class="h-4 w-4 text-zinc-400 transition-transform"
+                                    x-bind:class="{ 'rotate-90': expandedRules['{{ $ruleId }}'] }"
+                                />
+                                <div>
+                                    <flux:heading size="sm" class="font-medium">
+                                        {{ $rule['name'] ?? 'Unnamed Rule' }}
+                                    </flux:heading>
+                                    @if ($rule['id'] ?? false)
+                                        <flux:text size="xs" variant="subtle">ID: {{ $rule['id'] }}</flux:text>
+                                    @endif
+
+                                    @if ($newestVersion)
+                                        <flux:text size="sm" variant="subtle">
+                                            {{ $newestVersion['description'] ?? 'No description' }}
+                                        </flux:text>
+                                    @endif
+                                </div>
+                            </div>
+                        </div>
+
+                        <div
+                            class="hidden content-start items-center space-x-4 text-sm text-zinc-600 md:flex dark:text-zinc-400"
+                        >
+                            @if ($newestVersion)
+                                <div class="text-center">
+                                    <div class="text-xs font-medium">Start Date</div>
+                                    <div>{{ $newestVersion['startEffectiveDate'] ?? '-' }}</div>
+                                </div>
+                                <div class="text-center">
+                                    <div class="text-xs font-medium">End Date</div>
+                                    <div>{{ $newestVersion['endEffectiveDate'] ?? '-' }}</div>
+                                </div>
+                            @endif
+
+                            <div class="text-center">
+                                <div class="text-xs font-medium">Versions</div>
+                                <div>{{ count($fpaRuleVersions) }}</div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- Expanded Content -->
+                    <div
+                        x-show="expandedRules['{{ $ruleId }}']"
+                        x-transition:enter="transition duration-200 ease-out"
+                        x-transition:enter-start="scale-95 transform opacity-0"
+                        x-transition:enter-end="scale-100 transform opacity-100"
+                        x-transition:leave="transition duration-150 ease-in"
+                        x-transition:leave-start="scale-100 transform opacity-100"
+                        x-transition:leave-end="scale-95 transform opacity-0"
+                        class="border-t border-zinc-200 dark:border-zinc-700"
+                    >
+                        <div class="space-y-6 p-4">
+                            <!-- Rule Versions -->
+                            @foreach ($fpaRuleVersions as $version)
+                                <div class="space-y-4">
+                                    <div class="flex items-center justify-between">
+                                        <flux:heading size="sm" class="text-zinc-800 dark:text-zinc-200">
+                                            Version
+                                        </flux:heading>
+                                        <div
+                                            class="flex items-center space-x-4 text-sm text-zinc-600 dark:text-zinc-400"
+                                        >
+                                            <span>{{ $version['startEffectiveDate'] ?? '-' }}</span>
+                                            <span><flux:icon.arrow-long-right class="size-4" /></span>
+                                            <span>{{ $version['endEffectiveDate'] ?? '-' }}</span>
+                                        </div>
+                                    </div>
+
+                                    @if (! empty($version['description']))
+                                        <flux:text size="sm" variant="subtle">
+                                            {{ $version['description'] }}
+                                        </flux:text>
+                                    @endif
+
+                                    <!-- Triggers -->
+                                    @php
+                                        $triggers = $version['triggers'] ?? [];
+                                    @endphp
+
+                                    @if (! empty($triggers))
+                                        <div class="space-y-3">
+                                            <flux:heading size="sm" class="text-zinc-700 dark:text-zinc-300">
+                                                Triggers ({{ count($triggers) }})
+                                            </flux:heading>
+
+                                            <div class="grid gap-3">
+                                                @foreach ($triggers as $trigger)
+                                                    <div
+                                                        class="rounded-md border border-zinc-200 bg-zinc-50 p-3 dark:border-zinc-600 dark:bg-zinc-700/50"
+                                                    >
+                                                        <div
+                                                            class="grid grid-cols-1 gap-3 text-sm md:grid-cols-2 lg:grid-cols-3"
+                                                        >
+                                                            <!-- Job/Location -->
+                                                            <div>
+                                                                <div
+                                                                    class="font-medium text-zinc-700 dark:text-zinc-300"
+                                                                >
+                                                                    Job/Location
+                                                                </div>
+                                                                <div class="text-zinc-600 dark:text-zinc-400">
+                                                                    {{ $trigger['jobOrLocation']['qualifier'] ?? ($trigger['jobOrLocation']['name'] ?? '-') }}
+                                                                </div>
+                                                                @if (! empty($trigger['jobOrLocationEffectiveDate']))
+                                                                    <div
+                                                                        class="text-xs text-zinc-500 dark:text-zinc-500"
+                                                                    >
+                                                                        Effective:
+                                                                        {{ $trigger['jobOrLocationEffectiveDate'] }}
+                                                                    </div>
+                                                                @endif
+                                                            </div>
+
+                                                            <!-- Labor Category Entries -->
+                                                            <div>
+                                                                <div
+                                                                    class="font-medium text-zinc-700 dark:text-zinc-300"
+                                                                >
+                                                                    Labor Category
+                                                                </div>
+                                                                <div class="text-zinc-600 dark:text-zinc-400">
+                                                                    {{ $trigger['laborCategoryEntries'] ?? '-' }}
+                                                                </div>
+                                                            </div>
+
+                                                            <!-- Match Anywhere -->
+                                                            <div>
+                                                                <div
+                                                                    class="font-medium text-zinc-700 dark:text-zinc-300"
+                                                                >
+                                                                    Match Anywhere
+                                                                </div>
+                                                                <div class="text-zinc-600 dark:text-zinc-400">
+                                                                    {{ $trigger['matchAnywhere'] ?? false ? 'Yes' : 'No' }}
+                                                                </div>
+                                                            </div>
+
+                                                            <!-- Pay Codes -->
+                                                            <div class="md:col-span-2 lg:col-span-3">
+                                                                <div
+                                                                    class="font-medium text-zinc-700 dark:text-zinc-300"
+                                                                >
+                                                                    Pay Codes
+                                                                </div>
+                                                                <div class="text-zinc-600 dark:text-zinc-400">
+                                                                    @php
+                                                                        $payCodes = $trigger['payCodes'] ?? [];
+                                                                        $payCodeNames = collect($payCodes)
+                                                                            ->pluck('qualifier')
+                                                                            ->filter()
+                                                                            ->implode(', ');
+                                                                    @endphp
+
+                                                                    {{ $payCodeNames ?: '-' }}
+                                                                </div>
+                                                            </div>
+                                                        </div>
+
+                                                        <!-- Allocations -->
+                                                        @php
+                                                            $allocations = $trigger['allocations'] ?? [];
+                                                        @endphp
+
+                                                        @if (! empty($allocations))
+                                                            <div
+                                                                class="mt-4 border-t border-zinc-200 pt-3 dark:border-zinc-600"
+                                                            >
+                                                                <div
+                                                                    class="mb-3 font-medium text-zinc-700 dark:text-zinc-300"
+                                                                >
+                                                                    Allocations ({{ count($allocations) }})
+                                                                </div>
+
+                                                                <div class="space-y-2">
+                                                                    @foreach ($allocations as $allocation)
+                                                                        <div
+                                                                            class="rounded border border-zinc-300 bg-white p-2 dark:border-zinc-500 dark:bg-zinc-800"
+                                                                        >
+                                                                            <div
+                                                                                class="grid grid-cols-1 gap-2 text-sm md:grid-cols-2 lg:grid-cols-4"
+                                                                            >
+                                                                                <div>
+                                                                                    <span
+                                                                                        class="font-medium text-zinc-700 dark:text-zinc-300"
+                                                                                    >
+                                                                                        Percentage:
+                                                                                    </span>
+                                                                                    <span
+                                                                                        class="text-zinc-600 dark:text-zinc-400"
+                                                                                    >
+                                                                                        {{ $allocation['percentage'] ?? '0' }}%
+                                                                                    </span>
+                                                                                </div>
+
+                                                                                <div>
+                                                                                    <span
+                                                                                        class="font-medium text-zinc-700 dark:text-zinc-300"
+                                                                                    >
+                                                                                        Job:
+                                                                                    </span>
+                                                                                    <span
+                                                                                        class="text-zinc-600 dark:text-zinc-400"
+                                                                                    >
+                                                                                        {{ $allocation['job']['name'] ?? ($allocation['job']['qualifier'] ?? ($allocation['job']['id'] ?? '-')) }}
+                                                                                    </span>
+                                                                                </div>
+
+                                                                                <div>
+                                                                                    <span
+                                                                                        class="font-medium text-zinc-700 dark:text-zinc-300"
+                                                                                    >
+                                                                                        Wage Adj. Amount:
+                                                                                    </span>
+                                                                                    <span
+                                                                                        class="text-zinc-600 dark:text-zinc-400"
+                                                                                    >
+                                                                                        @if ($allocation['wageAdjustmentType'] === 2)
+                                                                                            x{{ $allocation['wageAdjustmentAmount'] ?? '0.00' }}
+                                                                                        @else
+                                                                                            ${{ $allocation['wageAdjustmentAmount'] ?? '0.00' }}
+                                                                                        @endif
+                                                                                    </span>
+                                                                                </div>
+
+                                                                                <div>
+                                                                                    <span
+                                                                                        class="font-medium text-zinc-700 dark:text-zinc-300"
+                                                                                    >
+                                                                                        Wage Adj. Type:
+                                                                                    </span>
+                                                                                    <span
+                                                                                        class="text-zinc-600 dark:text-zinc-400"
+                                                                                    >
+                                                                                        {{-- We have to hard-code the typeIds because they aren't easily found in documentation --}}
+                                                                                        {{-- This was tested in CFN032 with each type added to a trigger and viewed in the response --}}
+
+                                                                                        @switch($allocation['wageAdjustmentType'])
+                                                                                            @case('1')
+                                                                                                Addition
+
+                                                                                                @break
+                                                                                            @case('2')
+                                                                                                Multiplier
+
+                                                                                                @break
+                                                                                            @case('3')
+                                                                                                Flat Rate
+
+                                                                                                @break
+                                                                                            @case('4')
+                                                                                                None
+
+                                                                                                @break
+                                                                                            @default
+                                                                                                None
+
+                                                                                                @break
+                                                                                        @endswitch
+                                                                                    </span>
+                                                                                </div>
+                                                                            </div>
+
+                                                                            @if (! empty($allocation['laborCategoryEntries']))
+                                                                                <div
+                                                                                    class="mt-2 text-sm text-zinc-600 dark:text-zinc-400"
+                                                                                >
+                                                                                    <span
+                                                                                        class="font-medium text-zinc-700 dark:text-zinc-300"
+                                                                                    >
+                                                                                        Labor Category:
+                                                                                    </span>
+                                                                                    {{ $allocation['laborCategoryEntries'] }}
+                                                                                </div>
+                                                                            @endif
+                                                                        </div>
+                                                                    @endforeach
+                                                                </div>
+                                                            </div>
+                                                        @endif
+                                                    </div>
+                                                @endforeach
+                                            </div>
+                                        </div>
+                                    @else
+                                        <div class="py-4 text-center text-zinc-500 dark:text-zinc-400">
+                                            No triggers defined for this version
+                                        </div>
+                                    @endif
+                                </div>
+                            @endforeach
+                        </div>
+                    </div>
+                </div>
+            @endforeach
+        @else
+            <div class="py-8 text-center text-zinc-500 dark:text-zinc-400">
+                @if (! empty($search))
+                    No percent allocation rules found matching "{{ $search }}"
+                @else
+                    No percent allocation rules available
+                @endif
+            </div>
+        @endif
+    </div>
+
+    <!-- Pagination -->
+    @if ($paginatedData && $paginatedData->hasPages())
+        <div class="mt-6">
+            {{ $paginatedData->links(data: ['scrollTo' => false]) }}
+        </div>
+    @endif
+</div>

--- a/resources/views/livewire/tools/api-explorer/api-explorer.blade.php
+++ b/resources/views/livewire/tools/api-explorer/api-explorer.blade.php
@@ -263,6 +263,13 @@
                         Retrieve All Adjustment Rules
                     </x-api-endpoint-item>
                     <x-api-endpoint-item
+                        value="percent-allocation-rules-list"
+                        label="Retrieve All Percentage Allocation Rules"
+                        method="GET"
+                    >
+                        Retrieve All Percentage Allocation Rules
+                    </x-api-endpoint-item>
+                    <x-api-endpoint-item
                         value="paycodes-list"
                         label="Retrieve Paycodes as a Manager"
                         method="GET"

--- a/resources/views/livewire/tools/api-explorer/endpoints/locations-paginated-list.blade.php
+++ b/resources/views/livewire/tools/api-explorer/endpoints/locations-paginated-list.blade.php
@@ -69,7 +69,7 @@
         <x-api-data-table
             :paginatedData="$paginatedData"
             :columns="$tableColumns"
-            title="Pay Codes"
+            title="Locations"
             :totalRecords="$totalRecords"
             :search="$search"
             :sortField="$sortField"

--- a/resources/views/livewire/tools/api-explorer/endpoints/percent-allocation-rules-list.blade.php
+++ b/resources/views/livewire/tools/api-explorer/endpoints/percent-allocation-rules-list.blade.php
@@ -1,0 +1,61 @@
+<div class="space-y-6">
+    <!-- Endpoint Header -->
+    <x-api-endpoint-header
+        heading="Retrieve All Percent Allocation Rules"
+        method="GET"
+        wfm-endpoint="/api/v1/timekeeping/setup/percentage_allocation_rules"
+    />
+
+    <div class="grid grid-cols-1 gap-6 lg:grid-cols-2">
+        <!-- Input Section -->
+        <section class="space-y-4">
+            <!-- Execute Button -->
+            <div class="space-y-4">
+                <flux:button
+                    variant="primary"
+                    wire:click="executeRequest"
+                    wire:loading.attr="disabled"
+                    :disabled="!$isAuthenticated"
+                    class="disabled:opacity-50"
+                >
+                    <span wire:loading.remove wire:target="executeRequest">Execute Request</span>
+                    <span wire:loading wire:target="executeRequest">Loading...</span>
+                </flux:button>
+
+                @if (! $isAuthenticated)
+                    <x-alert type="warning" class="mb-4">Please authenticate to execute this request</x-alert>
+                @endif
+            </div>
+        </section>
+
+        <!-- Documentation Section -->
+        <div class="space-y-4">
+            <flux:heading size="md">Endpoint Information</flux:heading>
+
+            <div class="rounded-lg bg-zinc-50 p-4 dark:bg-zinc-800/50">
+                <flux:heading size="sm" class="mb-2">About This Endpoint</flux:heading>
+                <ul class="list-inside list-disc space-y-1 text-sm">
+                    <li>Retrieves all available Adjustment Rules</li>
+                    <li>Uses API user's access rights</li>
+                    <li>Review the table for at-a-glance information or the raw JSON output for additional details</li>
+                </ul>
+            </div>
+        </div>
+    </div>
+
+    {{-- Always show the table component once data has been loaded at least once --}}
+    @if (! empty($tableColumns) && $totalRecords > 0)
+        <x-tools.api-explorer.percent-allocation-rules-cards
+            :paginated-data="$paginatedData"
+            :columns="$tableColumns"
+            title="Percentage Allocation Rules"
+            :total-records="$totalRecords"
+            :search="$search"
+            :sort-field="$sortField"
+            :sort-direction="$sortDirection"
+            :per-page="$perPage"
+        />
+    @endif
+
+    <x-api-response :response="$apiResponse" :error="$errorMessage" :raw-json-cache-key="$rawJsonCacheKey" />
+</div>


### PR DESCRIPTION
### Description

This pull request introduces a UI for managing percent allocation rules in the API Explorer. The following changes are included:

- Added components and Livewire logic for displaying, paginating, and exporting percent allocation rules.
- Added support for fetching percent allocation rules through an API endpoint.
- Introduced a `getPercentAllocationRules` method to retrieve detailed data via the WFM API.
- Fixed the data table title, changing it from "Pay Codes" to "Locations."
- Removed `uniqid` as the default rule ID, replacing it with an empty string for predictable behavior.