### PR TITLE
Add support for Scheduled Report Requests in API Explorer

### DIFF
--- a/app/Livewire/Tools/ApiExplorer/Endpoints/ScheduledReportJobs.php
+++ b/app/Livewire/Tools/ApiExplorer/Endpoints/ScheduledReportJobs.php
@@ -1,0 +1,217 @@
+<?php
+
+namespace App\Livewire\Tools\ApiExplorer\Endpoints;
+
+use App\Livewire\Tools\ApiExplorer\BaseApiComponent;
+use Illuminate\Support\Collection;
+
+class ScheduledReportJobs extends BaseApiComponent
+{
+    public string $sortField = 'reportName';
+
+    public string $errorMessage = '';
+
+    public function getCacheKey(): string
+    {
+        $id = md5(session()?->id());
+
+        return "scheduled_report_jobs_$id";
+    }
+
+    public function getCacheTtl(): int
+    {
+        return 900; // 15 minutes
+    }
+
+    /**
+     * Transform data for CSV export
+     */
+    public function transformForCsv(array $data): array
+    {
+        return $this->transformForView($data);
+    }
+
+    /**
+     * Transform data for table view - extract most important fields
+     */
+    public function transformForView(array $data): array
+    {
+        return collect($data)->map(function ($report, $index) {
+            if (! is_array($report)) {
+                return null;
+            }
+
+            // Extract report parameters
+            $parameters = $this->extractReportParameters($report['reportParameter'] ?? []);
+
+            return [
+                'id' => $report['id'] ?? 'N/A',
+                'reportName' => $report['reportName'] ?? 'Unknown',
+                'title' => $report['title'] ?? '',
+                'description' => $report['description'] ?? '',
+                'reportRequestName' => $report['reportRequestName'] ?? '',
+                'sendAttachment' => isset($report['sendAttachment']) ? ($report['sendAttachment'] ? 'Yes' : 'No') : 'N/A',
+                'recipientCount' => isset($report['recipients']) && is_array($report['recipients']) ? count($report['recipients']) : 0,
+                'frequency' => $report['schedulingInfo']['frequency'] ?? 'N/A',
+                'startTime' => $report['schedulingInfo']['startTime'],
+                'startDateTime' => $report['schedulingInfo']['startDateTime'] ?? 'N/A',
+                'endDateTime' => $report['schedulingInfo']['endDateTime'] ?? 'N/A',
+                'forever' => isset($report['schedulingInfo']['forever']) ? ($report['schedulingInfo']['forever'] ? 'Yes' : 'No') : 'N/A',
+                'scheduledBy' => $report['scheduledBy']['qualifier'] ?? 'N/A',
+                'runAs' => $report['runAs']['qualifier'] ?? 'N/A',
+                // Add parameter fields
+                'dateRange' => $parameters['dateRange'],
+                'dataSource' => $parameters['dataSource'],
+                'outputFormat' => $parameters['outputFormat'],
+            ];
+        })->filter()->toArray(); // Remove null entries
+    }
+
+    /**
+     * Extract and format report parameters
+     */
+    private function extractReportParameters(array $reportParameter): array
+    {
+        $parameters = [
+            'dateRange' => 'N/A',
+            'dataSource' => 'N/A',
+            'outputFormat' => 'N/A',
+            'priority' => 'N/A',
+        ];
+
+        if (! isset($reportParameter['parameters']) || ! is_array($reportParameter['parameters'])) {
+            return $parameters;
+        }
+
+        foreach ($reportParameter['parameters'] as $param) {
+            if (! isset($param['name']) || ! isset($param['value'])) {
+                continue;
+            }
+
+            switch ($param['name']) {
+                case 'DateRange':
+                    $value = $param['value'];
+                    if (isset($value['startDate']) && isset($value['endDate'])) {
+                        $startDate = date('Y-m-d', strtotime($value['startDate']));
+                        $endDate = date('Y-m-d', strtotime($value['endDate']));
+                        $parameters['dateRange'] = "$startDate to $endDate";
+
+                        // Add symbolic period info if available
+                        if (isset($value['symbolicPeriod']['id'])) {
+                            $parameters['dateRange'] .= " (Period: {$value['symbolicPeriod']['id']})";
+                        }
+                    }
+                    break;
+
+                case 'DataSource':
+                    $value = $param['value'];
+                    if (isset($value['savedLocations']['id'])) {
+                        $parameters['dataSource'] = "Location ID: {$value['savedLocations']['id']}";
+                    } elseif (isset($value['hyperfind']['id'])) {
+                        $parameters['dataSource'] = "Hyperfind ID: {$value['hyperfind']['id']}";
+                    }
+
+                    break;
+
+                case 'Output Format':
+                    $value = $param['value'];
+                    if (isset($value['title'])) {
+                        $parameters['outputFormat'] = $value['title'];
+                    } elseif (isset($value['key'])) {
+                        $parameters['outputFormat'] = strtoupper($value['key']);
+                    }
+                    break;
+            }
+        }
+
+        return $parameters;
+    }
+
+    protected function getApiParams(): array
+    {
+        return [];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function getApiServiceCall(): callable
+    {
+        return fn ($params) => $this->wfmService->getScheduledReportJobs($params);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function getDataKeyFromResponse(): ?string
+    {
+        return 'reportRequests';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function getTotalFromResponseData(array $data): ?int
+    {
+        if (isset($data['reportRequests']) && is_array($data['reportRequests'])) {
+            return count($data['reportRequests']);
+        }
+
+        return count($data);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function getDataForCsvExport(): Collection
+    {
+        // Try to get cached data first
+        if (! empty($this->data)) {
+            return collect($this->data);
+        }
+
+        // If no cached data and we're authenticated, fetch fresh data
+        if ($this->isAuthenticated) {
+            $this->loadData();
+
+            return collect($this->data);
+        }
+
+        // Return empty collection if not authenticated or no data
+        return collect();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function getCsvColumns(): array
+    {
+        return $this->getTableColumns();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function getTableColumns(): array
+    {
+        return [
+            ['field' => 'id', 'label' => 'ID'],
+            ['field' => 'reportName', 'label' => 'Report Name'],
+            ['field' => 'title', 'label' => 'Title'],
+            ['field' => 'description', 'label' => 'Description'],
+            ['field' => 'sendAttachment', 'label' => 'Send Attachment'],
+            ['field' => 'recipientCount', 'label' => 'Recipients'],
+            ['field' => 'frequency', 'label' => 'Frequency'],
+            ['field' => 'startTime', 'label' => 'Start Time'],
+            ['field' => 'startDateTime', 'label' => 'Start Date'],
+            ['field' => 'endDateTime', 'label' => 'End Date'],
+            ['field' => 'forever', 'label' => 'Forever'],
+            ['field' => 'scheduledBy', 'label' => 'Scheduled By'],
+            ['field' => 'runAs', 'label' => 'Run As'],
+            // Add parameter columns
+            ['field' => 'dateRange', 'label' => 'Date Range'],
+            ['field' => 'dataSource', 'label' => 'Data Source'],
+            ['field' => 'outputFormat', 'label' => 'Output Format'],
+        ];
+    }
+}

--- a/resources/views/livewire/tools/api-explorer/api-explorer.blade.php
+++ b/resources/views/livewire/tools/api-explorer/api-explorer.blade.php
@@ -307,6 +307,13 @@
                     >Retrieve Paginated List of Locations
                     </x-api-endpoint-item>
                 </x-api-endpoint-group>
+                <x-api-endpoint-group title="Report Requests" name="document-text">
+                    <x-api-endpoint-item
+                        value="scheduled-report-jobs"
+                        label="Retrieve Paginated List of Scheduled Report Requests"
+                        method="POST">Retrieve Paginated List of Scheduled Report Requests
+                    </x-api-endpoint-item>
+                </x-api-endpoint-group>
             </div>
         </div>
 

--- a/resources/views/livewire/tools/api-explorer/endpoints/scheduled-report-jobs.blade.php
+++ b/resources/views/livewire/tools/api-explorer/endpoints/scheduled-report-jobs.blade.php
@@ -1,0 +1,64 @@
+<div class="space-y-6">
+    <!-- Endpoint Header -->
+    <x-api-endpoint-header
+        heading="Retrieve Paginated List of Scheduled Report Requests"
+        method="POST"
+        wfm-endpoint="/api/v1/platform/scheduled_reports/apply_read"
+    />
+
+    <div class="grid grid-cols-1 gap-6 lg:grid-cols-2">
+        <!-- Input Section -->
+        <section class="space-y-4">
+            <!-- Execute Button -->
+            <div class="space-y-4">
+                <flux:button
+                    variant="primary"
+                    wire:click="executeRequest"
+                    wire:loading.attr="disabled"
+                    :disabled="!$isAuthenticated"
+                    class="disabled:opacity-50"
+                >
+                    <span wire:loading.remove wire:target="executeRequest">Execute Request</span>
+                    <span wire:loading wire:target="executeRequest">Loading...</span>
+                </flux:button>
+
+                @if (! $isAuthenticated)
+                    <x-alert type="warning" class="mb-4">Please authenticate to execute this request</x-alert>
+                @endif
+            </div>
+        </section>
+
+        <!-- Documentation Section -->
+        <div class="space-y-4">
+            <flux:heading size="md">Endpoint Information</flux:heading>
+
+            <div class="rounded-lg bg-zinc-50 p-4 dark:bg-zinc-800/50">
+                <flux:heading size="sm" class="mb-2">About This Endpoint</flux:heading>
+                <ul class="list-inside list-disc space-y-1 text-sm">
+                    <li>Retrieves all Scheduled Reporting Jobs</li>
+                    <li>The associated Access Control Point is REPORT_SCHEDULING with action Allowed</li>
+                    <li>
+                        The information provided in the output may require the use of other endpoints to obtain all data
+                    </li>
+                    <li>Review the table for at-a-glance information or the raw JSON output for additional details</li>
+                </ul>
+            </div>
+        </div>
+    </div>
+
+    {{-- Always show the table component once data has been loaded at least once --}}
+    @if (! empty($tableColumns) && $totalRecords > 0)
+        <x-api-data-table
+            :paginatedData="$paginatedData"
+            :columns="$tableColumns"
+            title="Scheduled Report Jobs"
+            :totalRecords="$totalRecords"
+            :search="$search"
+            :sortField="$sortField"
+            :sortDirection="$sortDirection"
+            :perPage="$perPage"
+        />
+    @endif
+
+    <x-api-response :response="$apiResponse" :error="$errorMessage" :raw-json-cache-key="$rawJsonCacheKey" />
+</div>


### PR DESCRIPTION
Implemented a new feature in the API Explorer to support Scheduled Report Requests. This includes:  
- A new endpoint group for Scheduled Report Requests.  
- Backend functionality and API integration to retrieve paginated results.  
- UI components necessary for displaying and managing these requests.  

This enhancement improves reporting